### PR TITLE
Stabilize AI chat streaming: timeouts, parsing, terminal states, and duplicate-request guard

### DIFF
--- a/lib/screens/Loading_Screen.dart
+++ b/lib/screens/Loading_Screen.dart
@@ -17,6 +17,7 @@ import 'dart:typed_data';
 import 'package:flutter/foundation.dart';
 import 'package:path_provider/path_provider.dart';
 import '/screens/image_merge_service.dart';
+import 'package:mscanner/utils/async_request_gate.dart';
 
 
 /// ✅ LoadingScreen에서도 멀티 스캔 이미지를 1장으로 병합/압축해서 전송
@@ -63,6 +64,7 @@ class _LoadingScreenState extends State<LoadingScreen> {
 
   bool _isLoadingError = false;
   bool _hasNavigated = false;
+  final AsyncRequestGate _gptRequestGate = AsyncRequestGate();
 
   /// GPT 분석 Future는 initState 에서 바로 시작
   late Future<_PreparedVisionInput> _preparedFuture;
@@ -267,61 +269,65 @@ class _LoadingScreenState extends State<LoadingScreen> {
 
   /// 60초 타임아웃과 모든 예외를 동일하게 잡아서 에러 UI로
   Future<void> _handleGptResult() async {
-    try {
-      final prepared = await _preparedFuture.timeout(const Duration(seconds: 60));
-
-      // ✅ 미리보기용 첫 이미지 (ResultScreen에 보여줄 썸네일)
-      final File firstImage =
-      (widget.images != null && widget.images!.isNotEmpty)
-          ? widget.images!.first
-          : widget.image!;
-
-      final rawStream = VisionService.analyzeImageStream(
-        prepared.visionFile,
-        promptContext: prepared.promptContext,
-        maxOutputTokens: widget.maxOutputTokens,
-      );
-      final stream = rawStream.asBroadcastStream();
-      final firstRec = await _waitFirstRecommendFromStream(stream);
-
-      if (!_hasNavigated && mounted) {
-        _hasNavigated = true;
-        await LogService().logScanCompleted();
-
-        Navigator.of(context).pushReplacement(
-          MaterialPageRoute(
-            builder: (_) => ResultScreen(
-              image: firstImage,
-              images: widget.images,
-              responses: <String>[],
-              responseStream: stream,
-              initialFastRecommend: firstRec, // ✅ NEW
-              position: widget.position,
-              captureTime: widget.captureTime,
-              isTutorial: widget.isTutorial,
-            ),
-          ),
-        );
-      }
-    } catch (e) {
-      // ✅ 스트리밍 실패 시: 기존 Future 방식 fallback
+    await _gptRequestGate.run(() async {
       try {
         final prepared = await _preparedFuture.timeout(const Duration(seconds: 60));
-        final resp = await VisionService.analyzeImage(
+
+        // ✅ 미리보기용 첫 이미지 (ResultScreen에 보여줄 썸네일)
+        final File firstImage =
+        (widget.images != null && widget.images!.isNotEmpty)
+            ? widget.images!.first
+            : widget.image!;
+
+        final rawStream = VisionService.analyzeImageStream(
           prepared.visionFile,
           promptContext: prepared.promptContext,
           maxOutputTokens: widget.maxOutputTokens,
         );
+        final stream = rawStream
+            .timeout(const Duration(seconds: 45))
+            .asBroadcastStream();
+        final firstRec = await _waitFirstRecommendFromStream(stream);
 
         if (!_hasNavigated && mounted) {
           _hasNavigated = true;
           await LogService().logScanCompleted();
-          _navigateToResultScreen([resp], previewImage: prepared.visionFile);
+
+          Navigator.of(context).pushReplacement(
+            MaterialPageRoute(
+              builder: (_) => ResultScreen(
+                image: firstImage,
+                images: widget.images,
+                responses: <String>[],
+                responseStream: stream,
+                initialFastRecommend: firstRec, // ✅ NEW
+                position: widget.position,
+                captureTime: widget.captureTime,
+                isTutorial: widget.isTutorial,
+              ),
+            ),
+          );
         }
-      } catch (_) {
-        _showErrorUI();
+      } catch (e) {
+        // ✅ 스트리밍 실패 시: 기존 Future 방식 fallback
+        try {
+          final prepared = await _preparedFuture.timeout(const Duration(seconds: 60));
+          final resp = await VisionService.analyzeImage(
+            prepared.visionFile,
+            promptContext: prepared.promptContext,
+            maxOutputTokens: widget.maxOutputTokens,
+          );
+
+          if (!_hasNavigated && mounted) {
+            _hasNavigated = true;
+            await LogService().logScanCompleted();
+            _navigateToResultScreen([resp], previewImage: prepared.visionFile);
+          }
+        } catch (_) {
+          _showErrorUI();
+        }
       }
-    }
+    });
   }
 
 

--- a/lib/screens/Result_Screen.dart
+++ b/lib/screens/Result_Screen.dart
@@ -163,6 +163,8 @@ class _ResultScreenState extends State<ResultScreen> {
   StreamSubscription<String>? _aiStreamSub;
   final StringBuffer _aiStreamBuffer = StringBuffer();
   bool _aiStreamDone = false;
+  bool _aiStreamHadError = false;
+  String? _aiStreamErrorMessage;
 
   bool get _isWaitingFullMenu => widget.responseStream != null && !_aiStreamDone;
 
@@ -1784,6 +1786,18 @@ class _ResultScreenState extends State<ResultScreen> {
           ],
 
 
+          if (_aiStreamHadError && _aiStreamErrorMessage != null) ...[
+            Text(
+              _aiStreamErrorMessage!,
+              style: TextStyle(
+                fontFamily: 'SFPro',
+                fontSize: 12,
+                color: Colors.redAccent,
+              ),
+            ),
+            const SizedBox(height: 12),
+          ],
+
           ...rec.asMap().entries.map((entry) {
             final index = entry.key;
             final item = entry.value;
@@ -2530,6 +2544,26 @@ class _ResultScreenState extends State<ResultScreen> {
   int _viewerInitialIndex = 0;
   final GlobalKey _shareWidgetKey = GlobalKey();
 
+
+  void _completeAiStream({bool hadError = false, String? errorMessage}) {
+    _aiStreamDone = true;
+    _aiStreamHadError = hadError;
+    _aiStreamErrorMessage = errorMessage;
+
+    final full = _aiStreamBuffer.toString().trim();
+    if (full.isNotEmpty && !widget.responses.contains(full)) {
+      widget.responses.add(full);
+    }
+
+    _parseAiJson();
+    _kickoffRecommendedReveal();
+
+    if (_pendingSearchedMenuSave) {
+      _pendingSearchedMenuSave = false;
+      _saveSearchedMenuFireAndForget();
+    }
+  }
+
   @override
   void initState() {
     super.initState();
@@ -2541,7 +2575,9 @@ class _ResultScreenState extends State<ResultScreen> {
 
 // ✅ 스트리밍이 있으면: Result에서 바로 받아서 RECOMMEND 먼저 반영
     if (widget.responseStream != null) {
-      _aiStreamSub = widget.responseStream!.listen(
+      final guardedStream = widget.responseStream!
+          .timeout(const Duration(seconds: 45));
+      _aiStreamSub = guardedStream.listen(
             (delta) {
           _aiStreamBuffer.write(delta);
 
@@ -2565,25 +2601,26 @@ class _ResultScreenState extends State<ResultScreen> {
 
           if (mounted) setState(() {});
         },
-        onError: (_) {},
+        onError: (e) {
+          _completeAiStream(
+            hadError: true,
+            errorMessage: e is TimeoutException
+                ? 'Timed out while waiting for full menu stream.'
+                : 'Failed while receiving full menu stream.',
+          );
+          if (mounted) setState(() {});
+        },
         onDone: () {
-          _aiStreamDone = true;
           print('✅ stream done. fullLen=${_aiStreamBuffer.length}');
 
           final full = _aiStreamBuffer.toString().trim();
           print('✅ full head: ${full.substring(0, full.length > 180 ? 180 : full.length)}');
           print('✅ hasJsonStart=${full.contains("{")} hasJsonEnd=${full.contains("}")}');
-          if (full.isNotEmpty) {
-            widget.responses.add(full);
-          }
 
-          _parseAiJson();
-          _kickoffRecommendedReveal();
-
-          if (_pendingSearchedMenuSave) {
-            _pendingSearchedMenuSave = false;
-            _saveSearchedMenuFireAndForget();
-          }
+          _completeAiStream(
+            hadError: full.isEmpty,
+            errorMessage: full.isEmpty ? 'AI returned an empty stream response.' : null,
+          );
 
           if (mounted) setState(() {});
         },
@@ -3961,6 +3998,7 @@ class AnimatedDotsText extends StatefulWidget {
 class _AnimatedDotsTextState extends State<AnimatedDotsText> {
   Timer? _timer;
   int _dots = 0;
+
 
   @override
   void initState() {

--- a/lib/screens/vision_service.dart
+++ b/lib/screens/vision_service.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:http/http.dart' as http;
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import '/helpers/settings_helper.dart';
+import 'package:mscanner/utils/sse_event_parser.dart';
 
 class VisionService {
   // 기존: static Future<String> analyzeImage(File imageFile) async {
@@ -349,8 +350,11 @@ If it doesn’t seem food-related, just say so.
     };
 
     final template = ragPrefixMap[lang] ?? ragPrefixMap['en']!;
+    final safePromptContext = (promptContext ?? '').length > 3000
+        ? (promptContext ?? '').substring(0, 3000)
+        : (promptContext ?? '');
     final mergedPrompt = template
-        .replaceAll('{promptContext}', promptContext ?? '')
+        .replaceAll('{promptContext}', safePromptContext)
         .replaceAll('{question}', question ?? '');
 
     final mergedPromptWithProtocol = _streamProtocol + "\n" + mergedPrompt;
@@ -373,46 +377,48 @@ If it doesn’t seem food-related, just say so.
       'stream': true,
     };
 
-    final request = http.Request(
-      'POST',
-      Uri.parse('https://api.openai.com/v1/chat/completions'),
-    );
-    request.headers.addAll({
-      'Content-Type': 'application/json',
-      'Authorization': 'Bearer ${dotenv.env['API_KEY']}',
-    });
-    request.body = jsonEncode(payload);
+    final client = http.Client();
+    try {
+      final request = http.Request(
+        'POST',
+        Uri.parse('https://api.openai.com/v1/chat/completions'),
+      );
+      request.headers.addAll({
+        'Content-Type': 'application/json',
+        'Authorization': 'Bearer ${dotenv.env['API_KEY']}',
+      });
+      request.body = jsonEncode(payload);
 
-    final streamedResponse = await request.send();
-    if (streamedResponse.statusCode != 200) {
-      final errBody = await streamedResponse.stream.bytesToString();
-      throw Exception('Stream request failed: ${streamedResponse.statusCode} $errBody');
-    }
+      final streamedResponse = await client
+          .send(request)
+          .timeout(const Duration(seconds: 20));
+      if (streamedResponse.statusCode != 200) {
+        final errBody = await streamedResponse.stream.bytesToString();
+        throw Exception('Stream request failed: ${streamedResponse.statusCode} $errBody');
+      }
 
-    final decoder = utf8.decoder;
-    String sseBuffer = '';
+      final parser = SseEventParser();
+      final decoder = utf8.decoder;
+      var hasContent = false;
 
-    await for (final chunk in streamedResponse.stream.transform(decoder)) {
-      sseBuffer += chunk;
+      final guardedStream = streamedResponse.stream
+          .transform(decoder)
+          .timeout(const Duration(seconds: 45));
 
-      while (true) {
-        final splitIdx = sseBuffer.indexOf('\n\n');
-        if (splitIdx == -1) break;
-
-        final event = sseBuffer.substring(0, splitIdx);
-        sseBuffer = sseBuffer.substring(splitIdx + 2);
-
-        for (final line in event.split('\n')) {
-          final l = line.trim();
-          if (!l.startsWith('data:')) continue;
-
-          final data = l.substring(5).trim();
-          if (data == '[DONE]') return;
+      await for (final chunk in guardedStream) {
+        for (final data in parser.addChunk(chunk)) {
+          if (data == '[DONE]') {
+            if (!hasContent) {
+              throw const FormatException('Empty streaming response');
+            }
+            return;
+          }
 
           try {
             final j = jsonDecode(data);
             final delta = j['choices']?[0]?['delta']?['content'];
             if (delta is String && delta.isNotEmpty) {
+              hasContent = true;
               yield delta;
             }
           } catch (_) {
@@ -420,6 +426,24 @@ If it doesn’t seem food-related, just say so.
           }
         }
       }
+
+      for (final data in parser.flush()) {
+        if (data == '[DONE]') break;
+        try {
+          final j = jsonDecode(data);
+          final delta = j['choices']?[0]?['delta']?['content'];
+          if (delta is String && delta.isNotEmpty) {
+            hasContent = true;
+            yield delta;
+          }
+        } catch (_) {}
+      }
+
+      if (!hasContent) {
+        throw const FormatException('Empty streaming response');
+      }
+    } finally {
+      client.close();
     }
   }
 

--- a/lib/utils/async_request_gate.dart
+++ b/lib/utils/async_request_gate.dart
@@ -1,0 +1,15 @@
+class AsyncRequestGate {
+  bool _inFlight = false;
+
+  bool get inFlight => _inFlight;
+
+  Future<T?> run<T>(Future<T> Function() operation) async {
+    if (_inFlight) return null;
+    _inFlight = true;
+    try {
+      return await operation();
+    } finally {
+      _inFlight = false;
+    }
+  }
+}

--- a/lib/utils/sse_event_parser.dart
+++ b/lib/utils/sse_event_parser.dart
@@ -1,0 +1,41 @@
+class SseEventParser {
+  String _buffer = '';
+
+  List<String> addChunk(String chunk) {
+    if (chunk.isEmpty) return const [];
+    _buffer += chunk.replaceAll('\r\n', '\n');
+    return _drainCompleteEvents();
+  }
+
+  List<String> flush() {
+    if (_buffer.isEmpty) return const [];
+    final normalized = _buffer.replaceAll('\r\n', '\n').trim();
+    _buffer = '';
+    if (normalized.isEmpty) return const [];
+    return _extractDataLines(normalized);
+  }
+
+  List<String> _drainCompleteEvents() {
+    final payloads = <String>[];
+    while (true) {
+      final splitIdx = _buffer.indexOf('\n\n');
+      if (splitIdx == -1) break;
+
+      final event = _buffer.substring(0, splitIdx);
+      _buffer = _buffer.substring(splitIdx + 2);
+      payloads.addAll(_extractDataLines(event));
+    }
+    return payloads;
+  }
+
+  List<String> _extractDataLines(String event) {
+    final out = <String>[];
+    for (final raw in event.split('\n')) {
+      final line = raw.trim();
+      if (!line.startsWith('data:')) continue;
+      final data = line.substring(5).trim();
+      if (data.isNotEmpty) out.add(data);
+    }
+    return out;
+  }
+}

--- a/test/ai_stream_stability_test.dart
+++ b/test/ai_stream_stability_test.dart
@@ -1,0 +1,74 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mscanner/utils/async_request_gate.dart';
+import 'package:mscanner/utils/sse_event_parser.dart';
+
+void main() {
+  group('SSE parser robustness', () {
+    test('handles CRLF separated SSE events', () {
+      final parser = SseEventParser();
+      final out = parser.addChunk(
+        'data: {"choices":[{"delta":{"content":"RECO"}}]}\r\n\r\n',
+      );
+
+      expect(out, hasLength(1));
+      expect(out.first, contains('RECO'));
+    });
+
+    test('handles fragmented chunks and flush', () {
+      final parser = SseEventParser();
+      expect(parser.addChunk('data: part1'), isEmpty);
+      final out = parser.addChunk('\n\ndata: [DONE]\n\n');
+      expect(out, hasLength(2));
+      expect(out.last, '[DONE]');
+      expect(parser.flush(), isEmpty);
+    });
+
+    test('empty response event is detectable', () {
+      final parser = SseEventParser();
+      final out = parser.addChunk('data: [DONE]\n\n');
+      expect(out, ['[DONE]']);
+    });
+  });
+
+  group('Stream lifecycle guards', () {
+    test('stalled stream triggers timeout', () async {
+      final controller = StreamController<String>();
+      addTearDown(controller.close);
+
+      final timed = controller.stream.timeout(const Duration(milliseconds: 20));
+      expectLater(timed.drain(), throwsA(isA<TimeoutException>()));
+    });
+
+    test('stream error is surfaced', () async {
+      final controller = StreamController<String>();
+      addTearDown(controller.close);
+
+      Future.microtask(() => controller.addError(Exception('boom')));
+      expectLater(controller.stream.drain(), throwsException);
+    });
+
+    test('request gate resets loading state and prevents duplicate race', () async {
+      final gate = AsyncRequestGate();
+      var executions = 0;
+
+      final first = gate.run(() async {
+        executions += 1;
+        expect(gate.inFlight, isTrue);
+        await Future<void>.delayed(const Duration(milliseconds: 25));
+        throw StateError('fail once');
+      });
+
+      final second = gate.run(() async {
+        executions += 1;
+        return 2;
+      });
+
+      await expectLater(first, throwsA(isA<StateError>()));
+      expect(second, completion(isNull));
+      expect(gate.inFlight, isFalse);
+      expect(executions, 1);
+    });
+  });
+}


### PR DESCRIPTION
### Motivation
- Prevent intermittent infinite-loading/no-response in the AI chat flow by making streaming lifecycle deterministic and resilient. 
- Address long-running or half-open network connections, brittle SSE parsing, ignored stream errors, early navigation race, and oversized prompt payloads that increase stall risk.

### Description
- Add a robust SSE parser `lib/utils/sse_event_parser.dart` that normalizes CRLF, buffers fragmented chunks, and exposes `addChunk`/`flush` for reliable SSE event extraction.  
- Harden streaming transport in `lib/screens/vision_service.dart::VisionService.analyzeImageStream` by adding a request handshake timeout, an inactivity timeout on the streamed body, empty-stream detection (treat `[DONE]` without content as terminal error), prompt-context truncation (guardrail at ~3000 chars), and guaranteed HTTP client close.  
- Make loading flow single-entry safe by adding `lib/utils/async_request_gate.dart` and applying it in `lib/screens/Loading_Screen.dart::_handleGptResult` to prevent duplicate in-flight GPT runs and ensure deterministic cleanup; also apply a per-stream timeout before handing the stream to the Result screen.  
- Make result flow terminal on stream failure/completion by adding `_completeAiStream(...)` and wiring `onError`/`onDone` to finalize state, parse partial buffer, reveal available recommendations, and surface a short user-visible error message in `lib/screens/Result_Screen.dart`.  
- Add a focused unit test `test/ai_stream_stability_test.dart` that checks SSE parser robustness, stalled-stream timeout behavior, stream error surfacing, empty-response detection, and the async request gate semantics.

### Testing
- Added automated tests at `test/ai_stream_stability_test.dart` covering SSE parsing (CRLF and fragmented chunks), empty `[DONE]` detection, stream timeout behavior, stream error surfacing, and `AsyncRequestGate` race prevention; tests were added to the repo but could not be executed in this environment because the `flutter`/`dart` CLI was not available.  
- Performed static validation via repository diffs and file edits (no runtime failures introduced by local formatting tools in this environment).  
- Manual verification steps included in-code guards (timeouts and error handlers) to make runtime behavior deterministic under slow/erroneous network conditions; recommend running `flutter test` and instrumented QA on a device to validate timeouts and UI terminal states end-to-end.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b8108e742c832e81a15ecff4b9f1b9)