### PR TITLE
Improve guest premium UX: sign-in/convert flows, safety guards, and l10n

### DIFF
--- a/lib/l10n/app_ar.arb
+++ b/lib/l10n/app_ar.arb
@@ -369,5 +369,13 @@
   "tts_allergyPeanut": "فول سوداني",
   "tts_allergyMilk": "حليب",
   "tts_allergyShrimp": "جمبري",
-  "tts_allergyEgg": "بيضة"
+  "tts_allergyEgg": "بيضة",
+  "premiumLoginRequiredTitle": "Sign in to start Premium",
+  "premiumLoginRequiredMessage": "Sign in to restore purchases, keep your subscription, and access Premium across devices.",
+  "premiumLoginRequiredAction": "Sign in to continue",
+  "premiumGuestCta": "Sign in for Premium",
+  "premiumStartCta": "Start Premium",
+  "premiumGuestSectionTitle": "Connect your account before purchasing Premium in guest mode",
+  "premiumGuestSectionMessage": "Premium subscriptions are linked to your account so purchases can be restored and used across devices.",
+  "premiumGuestConvertButton": "Convert account to continue"
 }

--- a/lib/l10n/app_bn.arb
+++ b/lib/l10n/app_bn.arb
@@ -369,5 +369,13 @@
   "tts_allergyPeanut": "মুগফলি",
   "tts_allergyMilk": "দুধ",
   "tts_allergyShrimp": "চিংড়ি",
-  "tts_allergyEgg": "ডিম"
+  "tts_allergyEgg": "ডিম",
+  "premiumLoginRequiredTitle": "Sign in to start Premium",
+  "premiumLoginRequiredMessage": "Sign in to restore purchases, keep your subscription, and access Premium across devices.",
+  "premiumLoginRequiredAction": "Sign in to continue",
+  "premiumGuestCta": "Sign in for Premium",
+  "premiumStartCta": "Start Premium",
+  "premiumGuestSectionTitle": "Connect your account before purchasing Premium in guest mode",
+  "premiumGuestSectionMessage": "Premium subscriptions are linked to your account so purchases can be restored and used across devices.",
+  "premiumGuestConvertButton": "Convert account to continue"
 }

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -369,5 +369,13 @@
   "tts_allergyPeanut": "Erdnuss",
   "tts_allergyMilk": "Milch",
   "tts_allergyShrimp": "Garnele",
-  "tts_allergyEgg": "Ei"
+  "tts_allergyEgg": "Ei",
+  "premiumLoginRequiredTitle": "Sign in to start Premium",
+  "premiumLoginRequiredMessage": "Sign in to restore purchases, keep your subscription, and access Premium across devices.",
+  "premiumLoginRequiredAction": "Sign in to continue",
+  "premiumGuestCta": "Sign in for Premium",
+  "premiumStartCta": "Start Premium",
+  "premiumGuestSectionTitle": "Connect your account before purchasing Premium in guest mode",
+  "premiumGuestSectionMessage": "Premium subscriptions are linked to your account so purchases can be restored and used across devices.",
+  "premiumGuestConvertButton": "Convert account to continue"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -369,5 +369,13 @@
   "tts_allergyPeanut": "Peanut",
   "tts_allergyMilk": "Milk",
   "tts_allergyShrimp": "Shrimp",
-  "tts_allergyEgg": "Egg"
+  "tts_allergyEgg": "Egg",
+  "premiumLoginRequiredTitle": "Sign in to start Premium",
+  "premiumLoginRequiredMessage": "Sign in to restore purchases, keep your subscription, and access Premium across devices.",
+  "premiumLoginRequiredAction": "Sign in to continue",
+  "premiumGuestCta": "Sign in for Premium",
+  "premiumStartCta": "Start Premium",
+  "premiumGuestSectionTitle": "Connect your account before purchasing Premium in guest mode",
+  "premiumGuestSectionMessage": "Premium subscriptions are linked to your account so purchases can be restored and used across devices.",
+  "premiumGuestConvertButton": "Convert account to continue"
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -369,5 +369,13 @@
   "tts_allergyPeanut": "cacahuete",
   "tts_allergyMilk": "Leche",
   "tts_allergyShrimp": "camarón",
-  "tts_allergyEgg": "Huevo"
+  "tts_allergyEgg": "Huevo",
+  "premiumLoginRequiredTitle": "Sign in to start Premium",
+  "premiumLoginRequiredMessage": "Sign in to restore purchases, keep your subscription, and access Premium across devices.",
+  "premiumLoginRequiredAction": "Sign in to continue",
+  "premiumGuestCta": "Sign in for Premium",
+  "premiumStartCta": "Start Premium",
+  "premiumGuestSectionTitle": "Connect your account before purchasing Premium in guest mode",
+  "premiumGuestSectionMessage": "Premium subscriptions are linked to your account so purchases can be restored and used across devices.",
+  "premiumGuestConvertButton": "Convert account to continue"
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -369,5 +369,13 @@
   "tts_allergyPeanut": "cacahuète",
   "tts_allergyMilk": "lait",
   "tts_allergyShrimp": "Crevette",
-  "tts_allergyEgg": "Œuf"
+  "tts_allergyEgg": "Œuf",
+  "premiumLoginRequiredTitle": "Sign in to start Premium",
+  "premiumLoginRequiredMessage": "Sign in to restore purchases, keep your subscription, and access Premium across devices.",
+  "premiumLoginRequiredAction": "Sign in to continue",
+  "premiumGuestCta": "Sign in for Premium",
+  "premiumStartCta": "Start Premium",
+  "premiumGuestSectionTitle": "Connect your account before purchasing Premium in guest mode",
+  "premiumGuestSectionMessage": "Premium subscriptions are linked to your account so purchases can be restored and used across devices.",
+  "premiumGuestConvertButton": "Convert account to continue"
 }

--- a/lib/l10n/app_hi.arb
+++ b/lib/l10n/app_hi.arb
@@ -369,5 +369,13 @@
   "tts_allergyPeanut": "मूंगफली",
   "tts_allergyMilk": "दूध",
   "tts_allergyShrimp": "झींगा",
-  "tts_allergyEgg": "अंडा"
+  "tts_allergyEgg": "अंडा",
+  "premiumLoginRequiredTitle": "Sign in to start Premium",
+  "premiumLoginRequiredMessage": "Sign in to restore purchases, keep your subscription, and access Premium across devices.",
+  "premiumLoginRequiredAction": "Sign in to continue",
+  "premiumGuestCta": "Sign in for Premium",
+  "premiumStartCta": "Start Premium",
+  "premiumGuestSectionTitle": "Connect your account before purchasing Premium in guest mode",
+  "premiumGuestSectionMessage": "Premium subscriptions are linked to your account so purchases can be restored and used across devices.",
+  "premiumGuestConvertButton": "Convert account to continue"
 }

--- a/lib/l10n/app_id.arb
+++ b/lib/l10n/app_id.arb
@@ -369,5 +369,13 @@
   "tts_allergyPeanut": "Kacang tanah",
   "tts_allergyMilk": "Susu",
   "tts_allergyShrimp": "Udang",
-  "tts_allergyEgg": "Telur"
+  "tts_allergyEgg": "Telur",
+  "premiumLoginRequiredTitle": "Sign in to start Premium",
+  "premiumLoginRequiredMessage": "Sign in to restore purchases, keep your subscription, and access Premium across devices.",
+  "premiumLoginRequiredAction": "Sign in to continue",
+  "premiumGuestCta": "Sign in for Premium",
+  "premiumStartCta": "Start Premium",
+  "premiumGuestSectionTitle": "Connect your account before purchasing Premium in guest mode",
+  "premiumGuestSectionMessage": "Premium subscriptions are linked to your account so purchases can be restored and used across devices.",
+  "premiumGuestConvertButton": "Convert account to continue"
 }

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -369,5 +369,13 @@
   "tts_allergyPeanut": "ピーナッツ",
   "tts_allergyMilk": "ミルク",
   "tts_allergyShrimp": "エビ",
-  "tts_allergyEgg": "卵"
+  "tts_allergyEgg": "卵",
+  "premiumLoginRequiredTitle": "Sign in to start Premium",
+  "premiumLoginRequiredMessage": "Sign in to restore purchases, keep your subscription, and access Premium across devices.",
+  "premiumLoginRequiredAction": "Sign in to continue",
+  "premiumGuestCta": "Sign in for Premium",
+  "premiumStartCta": "Start Premium",
+  "premiumGuestSectionTitle": "Connect your account before purchasing Premium in guest mode",
+  "premiumGuestSectionMessage": "Premium subscriptions are linked to your account so purchases can be restored and used across devices.",
+  "premiumGuestConvertButton": "Convert account to continue"
 }

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -369,5 +369,13 @@
   "tts_allergyPeanut": "땅콩",
   "tts_allergyMilk": "우유",
   "tts_allergyShrimp": "새우",
-  "tts_allergyEgg": "달걀"
+  "tts_allergyEgg": "달걀",
+  "premiumLoginRequiredTitle": "프리미엄을 시작하려면 로그인이 필요해요",
+  "premiumLoginRequiredMessage": "구매 내역 복원, 구독 유지, 기기 변경 시 복원을 위해 계정 연결이 필요해요.",
+  "premiumLoginRequiredAction": "로그인 후 계속",
+  "premiumGuestCta": "로그인 후 프리미엄 시작",
+  "premiumStartCta": "프리미엄 시작",
+  "premiumGuestSectionTitle": "게스트 모드에서는 프리미엄 구매 전에 계정 연결이 필요해요",
+  "premiumGuestSectionMessage": "프리미엄 구독은 계정에 연결되어 구매 내역 복원과 기기 간 유지가 가능해요.",
+  "premiumGuestConvertButton": "계정 전환 후 계속"
 }

--- a/lib/l10n/app_mr.arb
+++ b/lib/l10n/app_mr.arb
@@ -369,5 +369,13 @@
   "tts_allergyPeanut": "शेंगदाणा",
   "tts_allergyMilk": "दूध",
   "tts_allergyShrimp": "झींगा",
-  "tts_allergyEgg": "अंडे"
+  "tts_allergyEgg": "अंडे",
+  "premiumLoginRequiredTitle": "Sign in to start Premium",
+  "premiumLoginRequiredMessage": "Sign in to restore purchases, keep your subscription, and access Premium across devices.",
+  "premiumLoginRequiredAction": "Sign in to continue",
+  "premiumGuestCta": "Sign in for Premium",
+  "premiumStartCta": "Start Premium",
+  "premiumGuestSectionTitle": "Connect your account before purchasing Premium in guest mode",
+  "premiumGuestSectionMessage": "Premium subscriptions are linked to your account so purchases can be restored and used across devices.",
+  "premiumGuestConvertButton": "Convert account to continue"
 }

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -369,5 +369,13 @@
   "tts_allergyPeanut": "Amendoim",
   "tts_allergyMilk": "Leite",
   "tts_allergyShrimp": "Camarão",
-  "tts_allergyEgg": "Ovo"
+  "tts_allergyEgg": "Ovo",
+  "premiumLoginRequiredTitle": "Sign in to start Premium",
+  "premiumLoginRequiredMessage": "Sign in to restore purchases, keep your subscription, and access Premium across devices.",
+  "premiumLoginRequiredAction": "Sign in to continue",
+  "premiumGuestCta": "Sign in for Premium",
+  "premiumStartCta": "Start Premium",
+  "premiumGuestSectionTitle": "Connect your account before purchasing Premium in guest mode",
+  "premiumGuestSectionMessage": "Premium subscriptions are linked to your account so purchases can be restored and used across devices.",
+  "premiumGuestConvertButton": "Convert account to continue"
 }

--- a/lib/l10n/app_pt_BR.arb
+++ b/lib/l10n/app_pt_BR.arb
@@ -369,5 +369,13 @@
   "tts_allergyPeanut": "Amendoim",
   "tts_allergyMilk": "Leite",
   "tts_allergyShrimp": "Camarão",
-  "tts_allergyEgg": "Ovo"
+  "tts_allergyEgg": "Ovo",
+  "premiumLoginRequiredTitle": "Sign in to start Premium",
+  "premiumLoginRequiredMessage": "Sign in to restore purchases, keep your subscription, and access Premium across devices.",
+  "premiumLoginRequiredAction": "Sign in to continue",
+  "premiumGuestCta": "Sign in for Premium",
+  "premiumStartCta": "Start Premium",
+  "premiumGuestSectionTitle": "Connect your account before purchasing Premium in guest mode",
+  "premiumGuestSectionMessage": "Premium subscriptions are linked to your account so purchases can be restored and used across devices.",
+  "premiumGuestConvertButton": "Convert account to continue"
 }

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -369,5 +369,13 @@
   "tts_allergyPeanut": "Арахис",
   "tts_allergyMilk": "молоко",
   "tts_allergyShrimp": "Креветки",
-  "tts_allergyEgg": "Яйцо"
+  "tts_allergyEgg": "Яйцо",
+  "premiumLoginRequiredTitle": "Sign in to start Premium",
+  "premiumLoginRequiredMessage": "Sign in to restore purchases, keep your subscription, and access Premium across devices.",
+  "premiumLoginRequiredAction": "Sign in to continue",
+  "premiumGuestCta": "Sign in for Premium",
+  "premiumStartCta": "Start Premium",
+  "premiumGuestSectionTitle": "Connect your account before purchasing Premium in guest mode",
+  "premiumGuestSectionMessage": "Premium subscriptions are linked to your account so purchases can be restored and used across devices.",
+  "premiumGuestConvertButton": "Convert account to continue"
 }

--- a/lib/l10n/app_te.arb
+++ b/lib/l10n/app_te.arb
@@ -369,5 +369,13 @@
   "tts_allergyPeanut": "వేరుశెనగ",
   "tts_allergyMilk": "పాలు",
   "tts_allergyShrimp": "రొయ్యలు",
-  "tts_allergyEgg": "గుడ్డు"
+  "tts_allergyEgg": "గుడ్డు",
+  "premiumLoginRequiredTitle": "Sign in to start Premium",
+  "premiumLoginRequiredMessage": "Sign in to restore purchases, keep your subscription, and access Premium across devices.",
+  "premiumLoginRequiredAction": "Sign in to continue",
+  "premiumGuestCta": "Sign in for Premium",
+  "premiumStartCta": "Start Premium",
+  "premiumGuestSectionTitle": "Connect your account before purchasing Premium in guest mode",
+  "premiumGuestSectionMessage": "Premium subscriptions are linked to your account so purchases can be restored and used across devices.",
+  "premiumGuestConvertButton": "Convert account to continue"
 }

--- a/lib/l10n/app_th.arb
+++ b/lib/l10n/app_th.arb
@@ -369,5 +369,13 @@
   "tts_allergyPeanut": "ถั่วลิสง",
   "tts_allergyMilk": "นม",
   "tts_allergyShrimp": "กุ้ง",
-  "tts_allergyEgg": "ไข่"
+  "tts_allergyEgg": "ไข่",
+  "premiumLoginRequiredTitle": "Sign in to start Premium",
+  "premiumLoginRequiredMessage": "Sign in to restore purchases, keep your subscription, and access Premium across devices.",
+  "premiumLoginRequiredAction": "Sign in to continue",
+  "premiumGuestCta": "Sign in for Premium",
+  "premiumStartCta": "Start Premium",
+  "premiumGuestSectionTitle": "Connect your account before purchasing Premium in guest mode",
+  "premiumGuestSectionMessage": "Premium subscriptions are linked to your account so purchases can be restored and used across devices.",
+  "premiumGuestConvertButton": "Convert account to continue"
 }

--- a/lib/l10n/app_tr.arb
+++ b/lib/l10n/app_tr.arb
@@ -369,5 +369,13 @@
   "tts_allergyPeanut": "Yer fıstığı",
   "tts_allergyMilk": "Süt",
   "tts_allergyShrimp": "Karides",
-  "tts_allergyEgg": "Yumurta"
+  "tts_allergyEgg": "Yumurta",
+  "premiumLoginRequiredTitle": "Sign in to start Premium",
+  "premiumLoginRequiredMessage": "Sign in to restore purchases, keep your subscription, and access Premium across devices.",
+  "premiumLoginRequiredAction": "Sign in to continue",
+  "premiumGuestCta": "Sign in for Premium",
+  "premiumStartCta": "Start Premium",
+  "premiumGuestSectionTitle": "Connect your account before purchasing Premium in guest mode",
+  "premiumGuestSectionMessage": "Premium subscriptions are linked to your account so purchases can be restored and used across devices.",
+  "premiumGuestConvertButton": "Convert account to continue"
 }

--- a/lib/l10n/app_ur.arb
+++ b/lib/l10n/app_ur.arb
@@ -369,5 +369,13 @@
   "tts_allergyPeanut": "مونگ پھلی",
   "tts_allergyMilk": "دودھ",
   "tts_allergyShrimp": "جھینگا",
-  "tts_allergyEgg": "انڈا"
+  "tts_allergyEgg": "انڈا",
+  "premiumLoginRequiredTitle": "Sign in to start Premium",
+  "premiumLoginRequiredMessage": "Sign in to restore purchases, keep your subscription, and access Premium across devices.",
+  "premiumLoginRequiredAction": "Sign in to continue",
+  "premiumGuestCta": "Sign in for Premium",
+  "premiumStartCta": "Start Premium",
+  "premiumGuestSectionTitle": "Connect your account before purchasing Premium in guest mode",
+  "premiumGuestSectionMessage": "Premium subscriptions are linked to your account so purchases can be restored and used across devices.",
+  "premiumGuestConvertButton": "Convert account to continue"
 }

--- a/lib/l10n/app_vi.arb
+++ b/lib/l10n/app_vi.arb
@@ -369,5 +369,13 @@
   "tts_allergyPeanut": "Hạt đậu phộng",
   "tts_allergyMilk": "Sữa",
   "tts_allergyShrimp": "Tôm",
-  "tts_allergyEgg": "Trứng"
+  "tts_allergyEgg": "Trứng",
+  "premiumLoginRequiredTitle": "Sign in to start Premium",
+  "premiumLoginRequiredMessage": "Sign in to restore purchases, keep your subscription, and access Premium across devices.",
+  "premiumLoginRequiredAction": "Sign in to continue",
+  "premiumGuestCta": "Sign in for Premium",
+  "premiumStartCta": "Start Premium",
+  "premiumGuestSectionTitle": "Connect your account before purchasing Premium in guest mode",
+  "premiumGuestSectionMessage": "Premium subscriptions are linked to your account so purchases can be restored and used across devices.",
+  "premiumGuestConvertButton": "Convert account to continue"
 }

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -369,5 +369,13 @@
   "tts_allergyPeanut": "花生",
   "tts_allergyMilk": "牛奶",
   "tts_allergyShrimp": "虾",
-  "tts_allergyEgg": "鸡蛋"
+  "tts_allergyEgg": "鸡蛋",
+  "premiumLoginRequiredTitle": "Sign in to start Premium",
+  "premiumLoginRequiredMessage": "Sign in to restore purchases, keep your subscription, and access Premium across devices.",
+  "premiumLoginRequiredAction": "Sign in to continue",
+  "premiumGuestCta": "Sign in for Premium",
+  "premiumStartCta": "Start Premium",
+  "premiumGuestSectionTitle": "Connect your account before purchasing Premium in guest mode",
+  "premiumGuestSectionMessage": "Premium subscriptions are linked to your account so purchases can be restored and used across devices.",
+  "premiumGuestConvertButton": "Convert account to continue"
 }

--- a/lib/l10n/app_zh_Hans.arb
+++ b/lib/l10n/app_zh_Hans.arb
@@ -369,5 +369,13 @@
   "tts_allergyPeanut": "花生",
   "tts_allergyMilk": "牛奶",
   "tts_allergyShrimp": "虾",
-  "tts_allergyEgg": "鸡蛋"
+  "tts_allergyEgg": "鸡蛋",
+  "premiumLoginRequiredTitle": "Sign in to start Premium",
+  "premiumLoginRequiredMessage": "Sign in to restore purchases, keep your subscription, and access Premium across devices.",
+  "premiumLoginRequiredAction": "Sign in to continue",
+  "premiumGuestCta": "Sign in for Premium",
+  "premiumStartCta": "Start Premium",
+  "premiumGuestSectionTitle": "Connect your account before purchasing Premium in guest mode",
+  "premiumGuestSectionMessage": "Premium subscriptions are linked to your account so purchases can be restored and used across devices.",
+  "premiumGuestConvertButton": "Convert account to continue"
 }

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -369,5 +369,13 @@
   "tts_allergyPeanut": "花生",
   "tts_allergyMilk": "牛奶",
   "tts_allergyShrimp": "蝦仁",
-  "tts_allergyEgg": "蛋"
+  "tts_allergyEgg": "蛋",
+  "premiumLoginRequiredTitle": "Sign in to start Premium",
+  "premiumLoginRequiredMessage": "Sign in to restore purchases, keep your subscription, and access Premium across devices.",
+  "premiumLoginRequiredAction": "Sign in to continue",
+  "premiumGuestCta": "Sign in for Premium",
+  "premiumStartCta": "Start Premium",
+  "premiumGuestSectionTitle": "Connect your account before purchasing Premium in guest mode",
+  "premiumGuestSectionMessage": "Premium subscriptions are linked to your account so purchases can be restored and used across devices.",
+  "premiumGuestConvertButton": "Convert account to continue"
 }

--- a/lib/l10n/gen_l10n/app_localizations.dart
+++ b/lib/l10n/gen_l10n/app_localizations.dart
@@ -2219,6 +2219,30 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Egg'**
   String get tts_allergyEgg;
+
+  /// No description provided for @premiumLoginRequiredTitle.
+  String get premiumLoginRequiredTitle;
+
+  /// No description provided for @premiumLoginRequiredMessage.
+  String get premiumLoginRequiredMessage;
+
+  /// No description provided for @premiumLoginRequiredAction.
+  String get premiumLoginRequiredAction;
+
+  /// No description provided for @premiumGuestCta.
+  String get premiumGuestCta;
+
+  /// No description provided for @premiumStartCta.
+  String get premiumStartCta;
+
+  /// No description provided for @premiumGuestSectionTitle.
+  String get premiumGuestSectionTitle;
+
+  /// No description provided for @premiumGuestSectionMessage.
+  String get premiumGuestSectionMessage;
+
+  /// No description provided for @premiumGuestConvertButton.
+  String get premiumGuestConvertButton;
 }
 
 class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {

--- a/lib/l10n/gen_l10n/app_localizations_ar.dart
+++ b/lib/l10n/gen_l10n/app_localizations_ar.dart
@@ -1067,4 +1067,29 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get tts_allergyEgg => 'بيضة';
+
+  @override
+  String get premiumLoginRequiredTitle => 'Sign in to start Premium';
+
+  @override
+  String get premiumLoginRequiredMessage => 'Sign in to restore purchases, keep your subscription, and access Premium across devices.';
+
+  @override
+  String get premiumLoginRequiredAction => 'Sign in to continue';
+
+  @override
+  String get premiumGuestCta => 'Sign in for Premium';
+
+  @override
+  String get premiumStartCta => 'Start Premium';
+
+  @override
+  String get premiumGuestSectionTitle => 'Connect your account before purchasing Premium in guest mode';
+
+  @override
+  String get premiumGuestSectionMessage => 'Premium subscriptions are linked to your account so purchases can be restored and used across devices.';
+
+  @override
+  String get premiumGuestConvertButton => 'Convert account to continue';
+
 }

--- a/lib/l10n/gen_l10n/app_localizations_bn.dart
+++ b/lib/l10n/gen_l10n/app_localizations_bn.dart
@@ -1067,4 +1067,29 @@ class AppLocalizationsBn extends AppLocalizations {
 
   @override
   String get tts_allergyEgg => 'ডিম';
+
+  @override
+  String get premiumLoginRequiredTitle => 'Sign in to start Premium';
+
+  @override
+  String get premiumLoginRequiredMessage => 'Sign in to restore purchases, keep your subscription, and access Premium across devices.';
+
+  @override
+  String get premiumLoginRequiredAction => 'Sign in to continue';
+
+  @override
+  String get premiumGuestCta => 'Sign in for Premium';
+
+  @override
+  String get premiumStartCta => 'Start Premium';
+
+  @override
+  String get premiumGuestSectionTitle => 'Connect your account before purchasing Premium in guest mode';
+
+  @override
+  String get premiumGuestSectionMessage => 'Premium subscriptions are linked to your account so purchases can be restored and used across devices.';
+
+  @override
+  String get premiumGuestConvertButton => 'Convert account to continue';
+
 }

--- a/lib/l10n/gen_l10n/app_localizations_de.dart
+++ b/lib/l10n/gen_l10n/app_localizations_de.dart
@@ -1067,4 +1067,29 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get tts_allergyEgg => 'Ei';
+
+  @override
+  String get premiumLoginRequiredTitle => 'Sign in to start Premium';
+
+  @override
+  String get premiumLoginRequiredMessage => 'Sign in to restore purchases, keep your subscription, and access Premium across devices.';
+
+  @override
+  String get premiumLoginRequiredAction => 'Sign in to continue';
+
+  @override
+  String get premiumGuestCta => 'Sign in for Premium';
+
+  @override
+  String get premiumStartCta => 'Start Premium';
+
+  @override
+  String get premiumGuestSectionTitle => 'Connect your account before purchasing Premium in guest mode';
+
+  @override
+  String get premiumGuestSectionMessage => 'Premium subscriptions are linked to your account so purchases can be restored and used across devices.';
+
+  @override
+  String get premiumGuestConvertButton => 'Convert account to continue';
+
 }

--- a/lib/l10n/gen_l10n/app_localizations_en.dart
+++ b/lib/l10n/gen_l10n/app_localizations_en.dart
@@ -1067,4 +1067,29 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get tts_allergyEgg => 'Egg';
+
+  @override
+  String get premiumLoginRequiredTitle => 'Sign in to start Premium';
+
+  @override
+  String get premiumLoginRequiredMessage => 'Sign in to restore purchases, keep your subscription, and access Premium across devices.';
+
+  @override
+  String get premiumLoginRequiredAction => 'Sign in to continue';
+
+  @override
+  String get premiumGuestCta => 'Sign in for Premium';
+
+  @override
+  String get premiumStartCta => 'Start Premium';
+
+  @override
+  String get premiumGuestSectionTitle => 'Connect your account before purchasing Premium in guest mode';
+
+  @override
+  String get premiumGuestSectionMessage => 'Premium subscriptions are linked to your account so purchases can be restored and used across devices.';
+
+  @override
+  String get premiumGuestConvertButton => 'Convert account to continue';
+
 }

--- a/lib/l10n/gen_l10n/app_localizations_es.dart
+++ b/lib/l10n/gen_l10n/app_localizations_es.dart
@@ -1067,4 +1067,29 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get tts_allergyEgg => 'Huevo';
+
+  @override
+  String get premiumLoginRequiredTitle => 'Sign in to start Premium';
+
+  @override
+  String get premiumLoginRequiredMessage => 'Sign in to restore purchases, keep your subscription, and access Premium across devices.';
+
+  @override
+  String get premiumLoginRequiredAction => 'Sign in to continue';
+
+  @override
+  String get premiumGuestCta => 'Sign in for Premium';
+
+  @override
+  String get premiumStartCta => 'Start Premium';
+
+  @override
+  String get premiumGuestSectionTitle => 'Connect your account before purchasing Premium in guest mode';
+
+  @override
+  String get premiumGuestSectionMessage => 'Premium subscriptions are linked to your account so purchases can be restored and used across devices.';
+
+  @override
+  String get premiumGuestConvertButton => 'Convert account to continue';
+
 }

--- a/lib/l10n/gen_l10n/app_localizations_fr.dart
+++ b/lib/l10n/gen_l10n/app_localizations_fr.dart
@@ -1067,4 +1067,29 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get tts_allergyEgg => 'Œuf';
+
+  @override
+  String get premiumLoginRequiredTitle => 'Sign in to start Premium';
+
+  @override
+  String get premiumLoginRequiredMessage => 'Sign in to restore purchases, keep your subscription, and access Premium across devices.';
+
+  @override
+  String get premiumLoginRequiredAction => 'Sign in to continue';
+
+  @override
+  String get premiumGuestCta => 'Sign in for Premium';
+
+  @override
+  String get premiumStartCta => 'Start Premium';
+
+  @override
+  String get premiumGuestSectionTitle => 'Connect your account before purchasing Premium in guest mode';
+
+  @override
+  String get premiumGuestSectionMessage => 'Premium subscriptions are linked to your account so purchases can be restored and used across devices.';
+
+  @override
+  String get premiumGuestConvertButton => 'Convert account to continue';
+
 }

--- a/lib/l10n/gen_l10n/app_localizations_hi.dart
+++ b/lib/l10n/gen_l10n/app_localizations_hi.dart
@@ -1067,4 +1067,29 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String get tts_allergyEgg => 'अंडा';
+
+  @override
+  String get premiumLoginRequiredTitle => 'Sign in to start Premium';
+
+  @override
+  String get premiumLoginRequiredMessage => 'Sign in to restore purchases, keep your subscription, and access Premium across devices.';
+
+  @override
+  String get premiumLoginRequiredAction => 'Sign in to continue';
+
+  @override
+  String get premiumGuestCta => 'Sign in for Premium';
+
+  @override
+  String get premiumStartCta => 'Start Premium';
+
+  @override
+  String get premiumGuestSectionTitle => 'Connect your account before purchasing Premium in guest mode';
+
+  @override
+  String get premiumGuestSectionMessage => 'Premium subscriptions are linked to your account so purchases can be restored and used across devices.';
+
+  @override
+  String get premiumGuestConvertButton => 'Convert account to continue';
+
 }

--- a/lib/l10n/gen_l10n/app_localizations_id.dart
+++ b/lib/l10n/gen_l10n/app_localizations_id.dart
@@ -1067,4 +1067,29 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String get tts_allergyEgg => 'Telur';
+
+  @override
+  String get premiumLoginRequiredTitle => 'Sign in to start Premium';
+
+  @override
+  String get premiumLoginRequiredMessage => 'Sign in to restore purchases, keep your subscription, and access Premium across devices.';
+
+  @override
+  String get premiumLoginRequiredAction => 'Sign in to continue';
+
+  @override
+  String get premiumGuestCta => 'Sign in for Premium';
+
+  @override
+  String get premiumStartCta => 'Start Premium';
+
+  @override
+  String get premiumGuestSectionTitle => 'Connect your account before purchasing Premium in guest mode';
+
+  @override
+  String get premiumGuestSectionMessage => 'Premium subscriptions are linked to your account so purchases can be restored and used across devices.';
+
+  @override
+  String get premiumGuestConvertButton => 'Convert account to continue';
+
 }

--- a/lib/l10n/gen_l10n/app_localizations_ja.dart
+++ b/lib/l10n/gen_l10n/app_localizations_ja.dart
@@ -1067,4 +1067,29 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get tts_allergyEgg => '卵';
+
+  @override
+  String get premiumLoginRequiredTitle => 'Sign in to start Premium';
+
+  @override
+  String get premiumLoginRequiredMessage => 'Sign in to restore purchases, keep your subscription, and access Premium across devices.';
+
+  @override
+  String get premiumLoginRequiredAction => 'Sign in to continue';
+
+  @override
+  String get premiumGuestCta => 'Sign in for Premium';
+
+  @override
+  String get premiumStartCta => 'Start Premium';
+
+  @override
+  String get premiumGuestSectionTitle => 'Connect your account before purchasing Premium in guest mode';
+
+  @override
+  String get premiumGuestSectionMessage => 'Premium subscriptions are linked to your account so purchases can be restored and used across devices.';
+
+  @override
+  String get premiumGuestConvertButton => 'Convert account to continue';
+
 }

--- a/lib/l10n/gen_l10n/app_localizations_ko.dart
+++ b/lib/l10n/gen_l10n/app_localizations_ko.dart
@@ -1067,4 +1067,29 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get tts_allergyEgg => '달걀';
+
+  @override
+  String get premiumLoginRequiredTitle => '프리미엄을 시작하려면 로그인이 필요해요';
+
+  @override
+  String get premiumLoginRequiredMessage => '구매 내역 복원, 구독 유지, 기기 변경 시 복원을 위해 계정 연결이 필요해요.';
+
+  @override
+  String get premiumLoginRequiredAction => '로그인 후 계속';
+
+  @override
+  String get premiumGuestCta => '로그인 후 프리미엄 시작';
+
+  @override
+  String get premiumStartCta => '프리미엄 시작';
+
+  @override
+  String get premiumGuestSectionTitle => '게스트 모드에서는 프리미엄 구매 전에 계정 연결이 필요해요';
+
+  @override
+  String get premiumGuestSectionMessage => '프리미엄 구독은 계정에 연결되어 구매 내역 복원과 기기 간 유지가 가능해요.';
+
+  @override
+  String get premiumGuestConvertButton => '계정 전환 후 계속';
+
 }

--- a/lib/l10n/gen_l10n/app_localizations_mr.dart
+++ b/lib/l10n/gen_l10n/app_localizations_mr.dart
@@ -1067,4 +1067,29 @@ class AppLocalizationsMr extends AppLocalizations {
 
   @override
   String get tts_allergyEgg => 'अंडे';
+
+  @override
+  String get premiumLoginRequiredTitle => 'Sign in to start Premium';
+
+  @override
+  String get premiumLoginRequiredMessage => 'Sign in to restore purchases, keep your subscription, and access Premium across devices.';
+
+  @override
+  String get premiumLoginRequiredAction => 'Sign in to continue';
+
+  @override
+  String get premiumGuestCta => 'Sign in for Premium';
+
+  @override
+  String get premiumStartCta => 'Start Premium';
+
+  @override
+  String get premiumGuestSectionTitle => 'Connect your account before purchasing Premium in guest mode';
+
+  @override
+  String get premiumGuestSectionMessage => 'Premium subscriptions are linked to your account so purchases can be restored and used across devices.';
+
+  @override
+  String get premiumGuestConvertButton => 'Convert account to continue';
+
 }

--- a/lib/l10n/gen_l10n/app_localizations_pt.dart
+++ b/lib/l10n/gen_l10n/app_localizations_pt.dart
@@ -1067,6 +1067,31 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get tts_allergyEgg => 'Ovo';
+
+  @override
+  String get premiumLoginRequiredTitle => 'Sign in to start Premium';
+
+  @override
+  String get premiumLoginRequiredMessage => 'Sign in to restore purchases, keep your subscription, and access Premium across devices.';
+
+  @override
+  String get premiumLoginRequiredAction => 'Sign in to continue';
+
+  @override
+  String get premiumGuestCta => 'Sign in for Premium';
+
+  @override
+  String get premiumStartCta => 'Start Premium';
+
+  @override
+  String get premiumGuestSectionTitle => 'Connect your account before purchasing Premium in guest mode';
+
+  @override
+  String get premiumGuestSectionMessage => 'Premium subscriptions are linked to your account so purchases can be restored and used across devices.';
+
+  @override
+  String get premiumGuestConvertButton => 'Convert account to continue';
+
 }
 
 /// The translations for Portuguese, as used in Brazil (`pt_BR`).
@@ -2132,4 +2157,29 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String get tts_allergyEgg => 'Ovo';
+
+  @override
+  String get premiumLoginRequiredTitle => 'Sign in to start Premium';
+
+  @override
+  String get premiumLoginRequiredMessage => 'Sign in to restore purchases, keep your subscription, and access Premium across devices.';
+
+  @override
+  String get premiumLoginRequiredAction => 'Sign in to continue';
+
+  @override
+  String get premiumGuestCta => 'Sign in for Premium';
+
+  @override
+  String get premiumStartCta => 'Start Premium';
+
+  @override
+  String get premiumGuestSectionTitle => 'Connect your account before purchasing Premium in guest mode';
+
+  @override
+  String get premiumGuestSectionMessage => 'Premium subscriptions are linked to your account so purchases can be restored and used across devices.';
+
+  @override
+  String get premiumGuestConvertButton => 'Convert account to continue';
+
 }

--- a/lib/l10n/gen_l10n/app_localizations_ru.dart
+++ b/lib/l10n/gen_l10n/app_localizations_ru.dart
@@ -1067,4 +1067,29 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get tts_allergyEgg => 'Яйцо';
+
+  @override
+  String get premiumLoginRequiredTitle => 'Sign in to start Premium';
+
+  @override
+  String get premiumLoginRequiredMessage => 'Sign in to restore purchases, keep your subscription, and access Premium across devices.';
+
+  @override
+  String get premiumLoginRequiredAction => 'Sign in to continue';
+
+  @override
+  String get premiumGuestCta => 'Sign in for Premium';
+
+  @override
+  String get premiumStartCta => 'Start Premium';
+
+  @override
+  String get premiumGuestSectionTitle => 'Connect your account before purchasing Premium in guest mode';
+
+  @override
+  String get premiumGuestSectionMessage => 'Premium subscriptions are linked to your account so purchases can be restored and used across devices.';
+
+  @override
+  String get premiumGuestConvertButton => 'Convert account to continue';
+
 }

--- a/lib/l10n/gen_l10n/app_localizations_te.dart
+++ b/lib/l10n/gen_l10n/app_localizations_te.dart
@@ -1067,4 +1067,29 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String get tts_allergyEgg => 'గుడ్డు';
+
+  @override
+  String get premiumLoginRequiredTitle => 'Sign in to start Premium';
+
+  @override
+  String get premiumLoginRequiredMessage => 'Sign in to restore purchases, keep your subscription, and access Premium across devices.';
+
+  @override
+  String get premiumLoginRequiredAction => 'Sign in to continue';
+
+  @override
+  String get premiumGuestCta => 'Sign in for Premium';
+
+  @override
+  String get premiumStartCta => 'Start Premium';
+
+  @override
+  String get premiumGuestSectionTitle => 'Connect your account before purchasing Premium in guest mode';
+
+  @override
+  String get premiumGuestSectionMessage => 'Premium subscriptions are linked to your account so purchases can be restored and used across devices.';
+
+  @override
+  String get premiumGuestConvertButton => 'Convert account to continue';
+
 }

--- a/lib/l10n/gen_l10n/app_localizations_th.dart
+++ b/lib/l10n/gen_l10n/app_localizations_th.dart
@@ -1067,4 +1067,29 @@ class AppLocalizationsTh extends AppLocalizations {
 
   @override
   String get tts_allergyEgg => 'ไข่';
+
+  @override
+  String get premiumLoginRequiredTitle => 'Sign in to start Premium';
+
+  @override
+  String get premiumLoginRequiredMessage => 'Sign in to restore purchases, keep your subscription, and access Premium across devices.';
+
+  @override
+  String get premiumLoginRequiredAction => 'Sign in to continue';
+
+  @override
+  String get premiumGuestCta => 'Sign in for Premium';
+
+  @override
+  String get premiumStartCta => 'Start Premium';
+
+  @override
+  String get premiumGuestSectionTitle => 'Connect your account before purchasing Premium in guest mode';
+
+  @override
+  String get premiumGuestSectionMessage => 'Premium subscriptions are linked to your account so purchases can be restored and used across devices.';
+
+  @override
+  String get premiumGuestConvertButton => 'Convert account to continue';
+
 }

--- a/lib/l10n/gen_l10n/app_localizations_tr.dart
+++ b/lib/l10n/gen_l10n/app_localizations_tr.dart
@@ -1067,4 +1067,29 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get tts_allergyEgg => 'Yumurta';
+
+  @override
+  String get premiumLoginRequiredTitle => 'Sign in to start Premium';
+
+  @override
+  String get premiumLoginRequiredMessage => 'Sign in to restore purchases, keep your subscription, and access Premium across devices.';
+
+  @override
+  String get premiumLoginRequiredAction => 'Sign in to continue';
+
+  @override
+  String get premiumGuestCta => 'Sign in for Premium';
+
+  @override
+  String get premiumStartCta => 'Start Premium';
+
+  @override
+  String get premiumGuestSectionTitle => 'Connect your account before purchasing Premium in guest mode';
+
+  @override
+  String get premiumGuestSectionMessage => 'Premium subscriptions are linked to your account so purchases can be restored and used across devices.';
+
+  @override
+  String get premiumGuestConvertButton => 'Convert account to continue';
+
 }

--- a/lib/l10n/gen_l10n/app_localizations_ur.dart
+++ b/lib/l10n/gen_l10n/app_localizations_ur.dart
@@ -1067,4 +1067,29 @@ class AppLocalizationsUr extends AppLocalizations {
 
   @override
   String get tts_allergyEgg => 'انڈا';
+
+  @override
+  String get premiumLoginRequiredTitle => 'Sign in to start Premium';
+
+  @override
+  String get premiumLoginRequiredMessage => 'Sign in to restore purchases, keep your subscription, and access Premium across devices.';
+
+  @override
+  String get premiumLoginRequiredAction => 'Sign in to continue';
+
+  @override
+  String get premiumGuestCta => 'Sign in for Premium';
+
+  @override
+  String get premiumStartCta => 'Start Premium';
+
+  @override
+  String get premiumGuestSectionTitle => 'Connect your account before purchasing Premium in guest mode';
+
+  @override
+  String get premiumGuestSectionMessage => 'Premium subscriptions are linked to your account so purchases can be restored and used across devices.';
+
+  @override
+  String get premiumGuestConvertButton => 'Convert account to continue';
+
 }

--- a/lib/l10n/gen_l10n/app_localizations_vi.dart
+++ b/lib/l10n/gen_l10n/app_localizations_vi.dart
@@ -1067,4 +1067,29 @@ class AppLocalizationsVi extends AppLocalizations {
 
   @override
   String get tts_allergyEgg => 'Trứng';
+
+  @override
+  String get premiumLoginRequiredTitle => 'Sign in to start Premium';
+
+  @override
+  String get premiumLoginRequiredMessage => 'Sign in to restore purchases, keep your subscription, and access Premium across devices.';
+
+  @override
+  String get premiumLoginRequiredAction => 'Sign in to continue';
+
+  @override
+  String get premiumGuestCta => 'Sign in for Premium';
+
+  @override
+  String get premiumStartCta => 'Start Premium';
+
+  @override
+  String get premiumGuestSectionTitle => 'Connect your account before purchasing Premium in guest mode';
+
+  @override
+  String get premiumGuestSectionMessage => 'Premium subscriptions are linked to your account so purchases can be restored and used across devices.';
+
+  @override
+  String get premiumGuestConvertButton => 'Convert account to continue';
+
 }

--- a/lib/l10n/gen_l10n/app_localizations_zh.dart
+++ b/lib/l10n/gen_l10n/app_localizations_zh.dart
@@ -1067,6 +1067,31 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get tts_allergyEgg => '鸡蛋';
+
+  @override
+  String get premiumLoginRequiredTitle => 'Sign in to start Premium';
+
+  @override
+  String get premiumLoginRequiredMessage => 'Sign in to restore purchases, keep your subscription, and access Premium across devices.';
+
+  @override
+  String get premiumLoginRequiredAction => 'Sign in to continue';
+
+  @override
+  String get premiumGuestCta => 'Sign in for Premium';
+
+  @override
+  String get premiumStartCta => 'Start Premium';
+
+  @override
+  String get premiumGuestSectionTitle => 'Connect your account before purchasing Premium in guest mode';
+
+  @override
+  String get premiumGuestSectionMessage => 'Premium subscriptions are linked to your account so purchases can be restored and used across devices.';
+
+  @override
+  String get premiumGuestConvertButton => 'Convert account to continue';
+
 }
 
 /// The translations for Chinese, using the Han script (`zh_Hans`).
@@ -2132,6 +2157,31 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
 
   @override
   String get tts_allergyEgg => '鸡蛋';
+
+  @override
+  String get premiumLoginRequiredTitle => 'Sign in to start Premium';
+
+  @override
+  String get premiumLoginRequiredMessage => 'Sign in to restore purchases, keep your subscription, and access Premium across devices.';
+
+  @override
+  String get premiumLoginRequiredAction => 'Sign in to continue';
+
+  @override
+  String get premiumGuestCta => 'Sign in for Premium';
+
+  @override
+  String get premiumStartCta => 'Start Premium';
+
+  @override
+  String get premiumGuestSectionTitle => 'Connect your account before purchasing Premium in guest mode';
+
+  @override
+  String get premiumGuestSectionMessage => 'Premium subscriptions are linked to your account so purchases can be restored and used across devices.';
+
+  @override
+  String get premiumGuestConvertButton => 'Convert account to continue';
+
 }
 
 /// The translations for Chinese, using the Han script (`zh_Hant`).
@@ -3197,4 +3247,29 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String get tts_allergyEgg => '蛋';
+
+  @override
+  String get premiumLoginRequiredTitle => 'Sign in to start Premium';
+
+  @override
+  String get premiumLoginRequiredMessage => 'Sign in to restore purchases, keep your subscription, and access Premium across devices.';
+
+  @override
+  String get premiumLoginRequiredAction => 'Sign in to continue';
+
+  @override
+  String get premiumGuestCta => 'Sign in for Premium';
+
+  @override
+  String get premiumStartCta => 'Start Premium';
+
+  @override
+  String get premiumGuestSectionTitle => 'Connect your account before purchasing Premium in guest mode';
+
+  @override
+  String get premiumGuestSectionMessage => 'Premium subscriptions are linked to your account so purchases can be restored and used across devices.';
+
+  @override
+  String get premiumGuestConvertButton => 'Convert account to continue';
+
 }

--- a/lib/screens/Home_Screen.dart
+++ b/lib/screens/Home_Screen.dart
@@ -31,6 +31,7 @@ import '/widgets/test_purchase_widget.dart';
 import '/screens/log_service.dart';
 import '/widgets/how_to_use_mscanner_card.dart';
 import '/analytics_service.dart';
+import '/screens/Login_Screen.dart';
 
 
 class HomeScreen extends StatefulWidget {
@@ -145,6 +146,74 @@ class _HomeScreenState extends State<HomeScreen> {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setInt('premium_overlay_closed_time', DateTime.now().millisecondsSinceEpoch);
     setState(() => _showPremiumOverlay = false);
+  }
+
+  Future<void> _showPurchaseSheet() async {
+    showModalBottomSheet(
+      context: context,
+      isScrollControlled: true,
+      backgroundColor: Colors.transparent,
+      builder: (_) {
+        return DraggableScrollableSheet(
+          initialChildSize: 0.7,
+          minChildSize: 0.5,
+          maxChildSize: 0.95,
+          builder: (ctx, scrollController) {
+            return Container(
+              decoration: const BoxDecoration(
+                color: Colors.white,
+                borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
+              ),
+              child: Padding(
+                padding: const EdgeInsets.only(top: 8),
+                child: SingleChildScrollView(
+                  controller: scrollController,
+                  child: TestPurchaseWidget(
+                    onPurchased: () {
+                      Navigator.of(context).maybePop(); // 바텀시트 닫기
+                      _closePremiumOverlay(); // 프리미엄 오버레이도 닫기
+                    },
+                  ),
+                ),
+              ),
+            );
+          },
+        );
+      },
+    );
+  }
+
+  Future<void> _showGuestPremiumPrompt() async {
+    final l10n = AppLocalizations.of(context)!;
+    await showCupertinoModalPopup<void>(
+      context: context,
+      builder: (ctx) => CupertinoActionSheet(
+        title: Text(l10n.premiumLoginRequiredTitle),
+        message: Text(l10n.premiumLoginRequiredMessage),
+        actions: [
+          CupertinoActionSheetAction(
+            onPressed: () {
+              Navigator.of(ctx).pop();
+              Navigator.of(context).push(
+                MaterialPageRoute(builder: (_) => LoginScreen()),
+              );
+            },
+            child: Text(l10n.premiumLoginRequiredAction),
+          ),
+          CupertinoActionSheetAction(
+            onPressed: () {
+              Navigator.of(ctx).pop();
+              setState(() => _selectedIndex = 4); // Settings 탭으로 이동
+            },
+            child: Text(l10n.premiumGuestConvertButton),
+          ),
+        ],
+        cancelButton: CupertinoActionSheetAction(
+          onPressed: () => Navigator.of(ctx).pop(),
+          child: Text(l10n.cancel),
+        ),
+      ),
+    );
   }
 
 
@@ -960,6 +1029,8 @@ class _HomeScreenState extends State<HomeScreen> {
                         imageFit: BoxFit.cover,       // ✅ 세로 기준으로 꽉 차게
                         imageAlignment: Alignment.topLeft, // ✅ 위쪽 기준
                         panelOffsetY: -60,                // ✅ 텍스트 위로 올리기
+                        isGuest: FirebaseAuth.instance.currentUser == null ||
+                            FirebaseAuth.instance.currentUser!.isAnonymous,
 
                         onPrimaryTap: () async {
                           await LogService().logPremiumCtaClick(placement: 'overlay', plan: 'subscription'); // ⑰ 프리미엄 CTA
@@ -967,38 +1038,13 @@ class _HomeScreenState extends State<HomeScreen> {
                             source: 'home_overlay',
                             trigger: 'overlay_cta',
                           );
-                          showModalBottomSheet(
-                            context: context,
-                            isScrollControlled: true,
-                            backgroundColor: Colors.transparent,
-                            builder: (_) {
-                              return DraggableScrollableSheet(
-                                initialChildSize: 0.7,
-                                minChildSize: 0.5,
-                                maxChildSize: 0.95,
-                                builder: (ctx, scrollController) {
-                                  return Container(
-                                    decoration: const BoxDecoration(
-                                      color: Colors.white,
-                                      borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
-                                    ),
-                                    child: Padding(
-                                      padding: const EdgeInsets.only(top: 8),
-                                      child: SingleChildScrollView(
-                                        controller: scrollController,
-                                        child: TestPurchaseWidget(
-                                          onPurchased: () {
-                                            Navigator.of(context).maybePop(); // 바텀시트 닫기
-                                            _closePremiumOverlay();          // 프리미엄 오버레이도 닫기
-                                          },
-                                        ),
-                                      ),
-                                    ),
-                                  );
-                                },
-                              );
-                            },
-                          );
+                          final user = FirebaseAuth.instance.currentUser;
+                          final isGuest = user == null || user.isAnonymous;
+                          if (isGuest) {
+                            await _showGuestPremiumPrompt();
+                            return;
+                          }
+                          await _showPurchaseSheet();
                         },
                         onClose: _closePremiumOverlay,
                       )

--- a/lib/screens/Setting_Screen.dart
+++ b/lib/screens/Setting_Screen.dart
@@ -781,11 +781,34 @@ class _SettingScreenState extends State<SettingScreen> {
               children: [
                 CupertinoFormRow(
                   child: Padding(
-                    padding: const EdgeInsets.symmetric(horizontal: 30.0),
-                    child: Text(
-                      AppLocalizations.of(context)!.guestPurchaseMessage,
-                      textAlign: TextAlign.center,
-                      style: TextStyle(fontSize: 14, color: textColor),
+                    padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 6),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          AppLocalizations.of(context)!.premiumGuestSectionTitle,
+                          style: TextStyle(
+                            fontSize: 14,
+                            fontWeight: FontWeight.w600,
+                            color: textColor,
+                          ),
+                        ),
+                        const SizedBox(height: 8),
+                        Text(
+                          AppLocalizations.of(context)!.premiumGuestSectionMessage,
+                          style: TextStyle(fontSize: 13, color: textColor.withOpacity(0.85)),
+                        ),
+                        const SizedBox(height: 12),
+                        CupertinoButton.filled(
+                          padding: const EdgeInsets.symmetric(vertical: 10, horizontal: 14),
+                          onPressed: _convertAccount,
+                          borderRadius: BorderRadius.circular(10),
+                          child: Text(
+                            AppLocalizations.of(context)!.premiumGuestConvertButton,
+                            style: const TextStyle(fontSize: 14, fontFamily: 'SFProText'),
+                          ),
+                        ),
+                      ],
                     ),
                   ),
                 ),

--- a/lib/widgets/premium_ad_overlay.dart
+++ b/lib/widgets/premium_ad_overlay.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:mscanner/l10n/gen_l10n/app_localizations.dart';
 
 class PremiumAdOverlay extends StatelessWidget {
   final ImageProvider image;
@@ -14,6 +15,7 @@ class PremiumAdOverlay extends StatelessWidget {
   final BoxFit imageFit;                // 이미지 채우기 방식 (cover / contain …)
   final Alignment imageAlignment;       // 이미지 앵커 위치
   final double panelOffsetY;            // 패널을 위/아래로 미세 이동 (음수=위로)
+  final bool isGuest;
 
   const PremiumAdOverlay({
     Key? key,
@@ -30,6 +32,7 @@ class PremiumAdOverlay extends StatelessWidget {
     this.imageFit = BoxFit.contain,
     this.imageAlignment = Alignment.topLeft,
     this.panelOffsetY = -50,             // 기본은 이동 없음
+    this.isGuest = false,
   }) : super(key: key);
 
   static const _rtlLangs = {'ar', 'ur'};
@@ -94,6 +97,7 @@ class PremiumAdOverlay extends StatelessWidget {
                           premiumMonthlyPrice: premiumMonthlyPrice,
                           isNarrow: isNarrow,
                           onPrimaryTap: onPrimaryTap,
+                          isGuest: isGuest,
                         ),
                       ),
                     ),
@@ -121,6 +125,7 @@ class _Panel extends StatelessWidget {
   final String premiumMonthlyPrice;
   final bool isNarrow;
   final VoidCallback? onPrimaryTap;
+  final bool isGuest;
 
   const _Panel({
     required this.strings,
@@ -128,10 +133,13 @@ class _Panel extends StatelessWidget {
     required this.premiumMonthlyPrice,
     required this.isNarrow,
     this.onPrimaryTap,
+    required this.isGuest,
   });
 
   @override
   Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    final ctaText = isGuest ? l10n.premiumGuestCta : l10n.premiumStartCta;
     final titleStyle = Theme.of(context).textTheme.headlineSmall?.copyWith(
       fontFamily: 'SFPro',
       fontSize: 20,   // 👈 원하는 크기로 고정
@@ -141,14 +149,14 @@ class _Panel extends StatelessWidget {
     );
 
     return DefaultTextStyle.merge(
-        style: const TextStyle(
-        decoration: TextDecoration.none,      // ✅ 밑줄 제거
-        decorationColor: Colors.transparent,  // ✅ 혹시 모를 데코 색도 무시
-    ),
-    child: Column(
-    mainAxisSize: MainAxisSize.min,
-    crossAxisAlignment: CrossAxisAlignment.stretch,
-    children: [
+      style: const TextStyle(
+        decoration: TextDecoration.none, // ✅ 밑줄 제거
+        decorationColor: Colors.transparent, // ✅ 혹시 모를 데코 색도 무시
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
         // 브랜드 텍스트 (불필요하다면 제거 가능)
         // Text("Mscanner", style: TextStyle(fontFamily: 'SFPro', color: Colors.white70, fontSize: 13, letterSpacing: 0.5)),
         SizedBox(height: isNarrow ? 6 : 10),
@@ -156,7 +164,12 @@ class _Panel extends StatelessWidget {
         SizedBox(height: isNarrow ? 8 : 12),
         _PriceRow(icon: Icons.block, label: strings.adFree, price: adFreePrice),
         const SizedBox(height: 6),
-        _PriceRow(icon: Icons.star_rounded, label: strings.premiumMonthly, price: premiumMonthlyPrice, trailing: strings.freeTrial),
+        _PriceRow(
+          icon: Icons.star_rounded,
+          label: strings.premiumMonthly,
+          price: premiumMonthlyPrice,
+          trailing: strings.freeTrial,
+        ),
         SizedBox(height: isNarrow ? 10 : 14),
         SizedBox(
           height: 44,
@@ -168,14 +181,30 @@ class _Panel extends StatelessWidget {
               elevation: 0,
             ),
             onPressed: onPrimaryTap,
-            child: Text(strings.cta, style: const TextStyle(fontFamily: 'SFPro', fontSize: 18, decoration: TextDecoration.none, fontWeight: FontWeight.w600)),
+            child: Text(
+              ctaText,
+              style: const TextStyle(
+                fontFamily: 'SFPro',
+                fontSize: 18,
+                decoration: TextDecoration.none,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
           ),
         ),
         const SizedBox(height: 6),
-        Text(strings.disclaimer,
-            style: const TextStyle(fontFamily: 'SFPro', color: Colors.white30, fontSize: 15, decoration: TextDecoration.none,      // ✅ 안전장치)),
-            )      )],
-    ));
+        Text(
+          strings.disclaimer,
+          style: const TextStyle(
+            fontFamily: 'SFPro',
+            color: Colors.white30,
+            fontSize: 15,
+            decoration: TextDecoration.none, // ✅ 안전장치
+          ),
+        ),
+      ],
+      ),
+    );
   }
 }
 

--- a/lib/widgets/test_purchase_widget.dart
+++ b/lib/widgets/test_purchase_widget.dart
@@ -105,7 +105,17 @@ class _TestPurchaseWidgetState extends State<TestPurchaseWidget> {
   }
 
   Future<void> _checkPreviousPurchase() async {
-    final uid = FirebaseAuth.instance.currentUser!.uid;
+    final currentUser = FirebaseAuth.instance.currentUser;
+    if (currentUser == null || currentUser.isAnonymous) {
+      if (!mounted) return;
+      setState(() {
+        _isAdFree = false;
+        _isSubscribed = false;
+      });
+      return;
+    }
+
+    final uid = currentUser.uid;
     bool isAdFree = false;
     bool isSubscribed = false;
 
@@ -260,7 +270,16 @@ class _TestPurchaseWidgetState extends State<TestPurchaseWidget> {
 
 
   Future<void> _onPurchaseSuccess(PurchaseDetails purchase) async {
-    final uid = FirebaseAuth.instance.currentUser!.uid;
+    final currentUser = FirebaseAuth.instance.currentUser;
+    if (currentUser == null || currentUser.isAnonymous) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(AppLocalizations.of(context)!.premiumLoginRequiredMessage)),
+      );
+      return;
+    }
+
+    final uid = currentUser.uid;
     final ref = FirebaseFirestore.instance.collection('user_points').doc(uid);
 
     try {
@@ -325,6 +344,14 @@ class _TestPurchaseWidgetState extends State<TestPurchaseWidget> {
   }
 
   void _buy(ProductDetails product) async {
+    final currentUser = FirebaseAuth.instance.currentUser;
+    if (currentUser == null || currentUser.isAnonymous) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(AppLocalizations.of(context)!.premiumLoginRequiredMessage)),
+      );
+      return;
+    }
+
     await _log.logPremiumCtaClick(
       placement: 'settings',
       plan: product.id == 'premium_monthly' ? 'monthly' : 'remove_ads',


### PR DESCRIPTION
### Motivation
- Prevent guest users from hitting a dead-end when tapping premium CTAs and instead guide them to sign in or convert their account. 
- Preserve the current purchase flow for signed-in users while making the overlay/setting CTAs context-aware. 
- Ensure purchase code is null-safe for guest/null Firebase auth and add localized strings for the new UX.

### Description
- Home: added `_showPurchaseSheet()` and `_showGuestPremiumPrompt()` and updated the premium overlay CTA to branch on auth state so guests see a `CupertinoActionSheet` (login / convert) while signed-in users open the `TestPurchaseWidget` sheet (`lib/screens/Home_Screen.dart`).
- Settings: replaced the text-only guest premium note with a titled explanation + CTA button that calls `_convertAccount()`; kept `TestPurchaseWidget` visible for signed-in users (`lib/screens/Setting_Screen.dart`).
- Purchase widget: hardened `TestPurchaseWidget` by replacing unsafe `currentUser!.uid` usage with safe checks in `_checkPreviousPurchase()`, `_onPurchaseSuccess()`, and `_buy()` to early-return for guest/null users and show SnackBar feedback instead of crashing (`lib/widgets/test_purchase_widget.dart`).
- Overlay widget: added `isGuest` parameter and switched the CTA label by l10n (`premiumGuestCta` / `premiumStartCta`) while preserving existing layout and analytics hooks (`lib/widgets/premium_ad_overlay.dart`).
- Localization: added the requested l10n keys (`premiumLoginRequiredTitle`, `premiumLoginRequiredMessage`, `premiumLoginRequiredAction`, `premiumGuestCta`, `premiumStartCta`, `premiumGuestSectionTitle`, `premiumGuestSectionMessage`, `premiumGuestConvertButton`) to ARB files across the supported locales and updated generated localization getters/implementations so they are available at call sites (`lib/l10n/*.arb`, `lib/l10n/gen_l10n/*`).
- Kept existing analytics/logging calls and style/structure as-is where possible.

### Testing
- Performed repository checks and committed changes (`git status` / commit) which succeeded and show the modified files and commit (`git show --stat`).
- Attempted `flutter gen-l10n` but the runner environment did not provide `flutter`, so language generation was applied via scripted edits instead and generated files in `lib/l10n/gen_l10n/` were updated in-repo; `flutter gen-l10n` could not be executed (`/bin/bash: flutter: command not found`).
- Attempted `dart format` but the runner environment did not provide `dart`, so auto-format could not be executed (`/bin/bash: dart: command not found`).
- No runtime/unit tests were executed in this environment; changes to localization and null-safety guards were made and committed, but please run `flutter pub get`, `flutter gen-l10n`, `dart format` and a local build/test (`flutter analyze` / `flutter run` or CI) to validate compilation and runtime behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d1f7ce742c832eba9dac585967912c)