### PR TITLE
Separate single/multi scan Vision prompts and add multi-scan JSON handling

### DIFF
--- a/lib/l10n/app_ar.arb
+++ b/lib/l10n/app_ar.arb
@@ -377,5 +377,49 @@
   "premiumStartCta": "Start Premium",
   "premiumGuestSectionTitle": "Connect your account before purchasing Premium in guest mode",
   "premiumGuestSectionMessage": "Premium subscriptions are linked to your account so purchases can be restored and used across devices.",
-  "premiumGuestConvertButton": "Convert account to continue"
+  "premiumGuestConvertButton": "Convert account to continue",
+  "multiScanSummaryTitle": "Multi-scan summary",
+  "multiScanPhotoItemsDetected": "Photo {index}: {count} items detected",
+  "@multiScanPhotoItemsDetected": {
+    "placeholders": {
+      "index": {},
+      "count": {}
+    }
+  },
+  "multiScanPhotoItemsUnclear": "Photo {index}: {count} items detected / {unclear} unclear",
+  "@multiScanPhotoItemsUnclear": {
+    "placeholders": {
+      "index": {},
+      "count": {},
+      "unclear": {}
+    }
+  },
+  "multiScanNoReadableItems": "Photo {index}: no readable menu items detected",
+  "@multiScanNoReadableItems": {
+    "placeholders": {
+      "index": {}
+    }
+  },
+  "multiScanTotalSummary": "Total {total} detected / {unique} after duplicate removal",
+  "@multiScanTotalSummary": {
+    "placeholders": {
+      "total": {},
+      "unique": {}
+    }
+  },
+  "multiScanTotalSummaryWithDuplicates": "Total {total} detected / {unique} after duplicate removal ({duplicates} duplicates)",
+  "@multiScanTotalSummaryWithDuplicates": {
+    "placeholders": {
+      "total": {},
+      "unique": {},
+      "duplicates": {}
+    }
+  },
+  "multiScanTotalPhotoCount": "Total photo count: {count}",
+  "@multiScanTotalPhotoCount": {
+    "placeholders": {
+      "count": {}
+    }
+  },
+  "multiScanDetailsUnavailable": "Photo analysis details are unavailable, but the merged result is safe to view."
 }

--- a/lib/l10n/app_bn.arb
+++ b/lib/l10n/app_bn.arb
@@ -377,5 +377,49 @@
   "premiumStartCta": "Start Premium",
   "premiumGuestSectionTitle": "Connect your account before purchasing Premium in guest mode",
   "premiumGuestSectionMessage": "Premium subscriptions are linked to your account so purchases can be restored and used across devices.",
-  "premiumGuestConvertButton": "Convert account to continue"
+  "premiumGuestConvertButton": "Convert account to continue",
+  "multiScanSummaryTitle": "Multi-scan summary",
+  "multiScanPhotoItemsDetected": "Photo {index}: {count} items detected",
+  "@multiScanPhotoItemsDetected": {
+    "placeholders": {
+      "index": {},
+      "count": {}
+    }
+  },
+  "multiScanPhotoItemsUnclear": "Photo {index}: {count} items detected / {unclear} unclear",
+  "@multiScanPhotoItemsUnclear": {
+    "placeholders": {
+      "index": {},
+      "count": {},
+      "unclear": {}
+    }
+  },
+  "multiScanNoReadableItems": "Photo {index}: no readable menu items detected",
+  "@multiScanNoReadableItems": {
+    "placeholders": {
+      "index": {}
+    }
+  },
+  "multiScanTotalSummary": "Total {total} detected / {unique} after duplicate removal",
+  "@multiScanTotalSummary": {
+    "placeholders": {
+      "total": {},
+      "unique": {}
+    }
+  },
+  "multiScanTotalSummaryWithDuplicates": "Total {total} detected / {unique} after duplicate removal ({duplicates} duplicates)",
+  "@multiScanTotalSummaryWithDuplicates": {
+    "placeholders": {
+      "total": {},
+      "unique": {},
+      "duplicates": {}
+    }
+  },
+  "multiScanTotalPhotoCount": "Total photo count: {count}",
+  "@multiScanTotalPhotoCount": {
+    "placeholders": {
+      "count": {}
+    }
+  },
+  "multiScanDetailsUnavailable": "Photo analysis details are unavailable, but the merged result is safe to view."
 }

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -377,5 +377,49 @@
   "premiumStartCta": "Start Premium",
   "premiumGuestSectionTitle": "Connect your account before purchasing Premium in guest mode",
   "premiumGuestSectionMessage": "Premium subscriptions are linked to your account so purchases can be restored and used across devices.",
-  "premiumGuestConvertButton": "Convert account to continue"
+  "premiumGuestConvertButton": "Convert account to continue",
+  "multiScanSummaryTitle": "Multi-scan summary",
+  "multiScanPhotoItemsDetected": "Photo {index}: {count} items detected",
+  "@multiScanPhotoItemsDetected": {
+    "placeholders": {
+      "index": {},
+      "count": {}
+    }
+  },
+  "multiScanPhotoItemsUnclear": "Photo {index}: {count} items detected / {unclear} unclear",
+  "@multiScanPhotoItemsUnclear": {
+    "placeholders": {
+      "index": {},
+      "count": {},
+      "unclear": {}
+    }
+  },
+  "multiScanNoReadableItems": "Photo {index}: no readable menu items detected",
+  "@multiScanNoReadableItems": {
+    "placeholders": {
+      "index": {}
+    }
+  },
+  "multiScanTotalSummary": "Total {total} detected / {unique} after duplicate removal",
+  "@multiScanTotalSummary": {
+    "placeholders": {
+      "total": {},
+      "unique": {}
+    }
+  },
+  "multiScanTotalSummaryWithDuplicates": "Total {total} detected / {unique} after duplicate removal ({duplicates} duplicates)",
+  "@multiScanTotalSummaryWithDuplicates": {
+    "placeholders": {
+      "total": {},
+      "unique": {},
+      "duplicates": {}
+    }
+  },
+  "multiScanTotalPhotoCount": "Total photo count: {count}",
+  "@multiScanTotalPhotoCount": {
+    "placeholders": {
+      "count": {}
+    }
+  },
+  "multiScanDetailsUnavailable": "Photo analysis details are unavailable, but the merged result is safe to view."
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -377,5 +377,49 @@
   "premiumStartCta": "Start Premium",
   "premiumGuestSectionTitle": "Connect your account before purchasing Premium in guest mode",
   "premiumGuestSectionMessage": "Premium subscriptions are linked to your account so purchases can be restored and used across devices.",
-  "premiumGuestConvertButton": "Convert account to continue"
+  "premiumGuestConvertButton": "Convert account to continue",
+  "multiScanSummaryTitle": "Multi-scan summary",
+  "multiScanPhotoItemsDetected": "Photo {index}: {count} items detected",
+  "@multiScanPhotoItemsDetected": {
+    "placeholders": {
+      "index": {},
+      "count": {}
+    }
+  },
+  "multiScanPhotoItemsUnclear": "Photo {index}: {count} items detected / {unclear} unclear",
+  "@multiScanPhotoItemsUnclear": {
+    "placeholders": {
+      "index": {},
+      "count": {},
+      "unclear": {}
+    }
+  },
+  "multiScanNoReadableItems": "Photo {index}: no readable menu items detected",
+  "@multiScanNoReadableItems": {
+    "placeholders": {
+      "index": {}
+    }
+  },
+  "multiScanTotalSummary": "Total {total} detected / {unique} after duplicate removal",
+  "@multiScanTotalSummary": {
+    "placeholders": {
+      "total": {},
+      "unique": {}
+    }
+  },
+  "multiScanTotalSummaryWithDuplicates": "Total {total} detected / {unique} after duplicate removal ({duplicates} duplicates)",
+  "@multiScanTotalSummaryWithDuplicates": {
+    "placeholders": {
+      "total": {},
+      "unique": {},
+      "duplicates": {}
+    }
+  },
+  "multiScanTotalPhotoCount": "Total photo count: {count}",
+  "@multiScanTotalPhotoCount": {
+    "placeholders": {
+      "count": {}
+    }
+  },
+  "multiScanDetailsUnavailable": "Photo analysis details are unavailable, but the merged result is safe to view."
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -377,5 +377,49 @@
   "premiumStartCta": "Start Premium",
   "premiumGuestSectionTitle": "Connect your account before purchasing Premium in guest mode",
   "premiumGuestSectionMessage": "Premium subscriptions are linked to your account so purchases can be restored and used across devices.",
-  "premiumGuestConvertButton": "Convert account to continue"
+  "premiumGuestConvertButton": "Convert account to continue",
+  "multiScanSummaryTitle": "Multi-scan summary",
+  "multiScanPhotoItemsDetected": "Photo {index}: {count} items detected",
+  "@multiScanPhotoItemsDetected": {
+    "placeholders": {
+      "index": {},
+      "count": {}
+    }
+  },
+  "multiScanPhotoItemsUnclear": "Photo {index}: {count} items detected / {unclear} unclear",
+  "@multiScanPhotoItemsUnclear": {
+    "placeholders": {
+      "index": {},
+      "count": {},
+      "unclear": {}
+    }
+  },
+  "multiScanNoReadableItems": "Photo {index}: no readable menu items detected",
+  "@multiScanNoReadableItems": {
+    "placeholders": {
+      "index": {}
+    }
+  },
+  "multiScanTotalSummary": "Total {total} detected / {unique} after duplicate removal",
+  "@multiScanTotalSummary": {
+    "placeholders": {
+      "total": {},
+      "unique": {}
+    }
+  },
+  "multiScanTotalSummaryWithDuplicates": "Total {total} detected / {unique} after duplicate removal ({duplicates} duplicates)",
+  "@multiScanTotalSummaryWithDuplicates": {
+    "placeholders": {
+      "total": {},
+      "unique": {},
+      "duplicates": {}
+    }
+  },
+  "multiScanTotalPhotoCount": "Total photo count: {count}",
+  "@multiScanTotalPhotoCount": {
+    "placeholders": {
+      "count": {}
+    }
+  },
+  "multiScanDetailsUnavailable": "Photo analysis details are unavailable, but the merged result is safe to view."
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -377,5 +377,49 @@
   "premiumStartCta": "Start Premium",
   "premiumGuestSectionTitle": "Connect your account before purchasing Premium in guest mode",
   "premiumGuestSectionMessage": "Premium subscriptions are linked to your account so purchases can be restored and used across devices.",
-  "premiumGuestConvertButton": "Convert account to continue"
+  "premiumGuestConvertButton": "Convert account to continue",
+  "multiScanSummaryTitle": "Multi-scan summary",
+  "multiScanPhotoItemsDetected": "Photo {index}: {count} items detected",
+  "@multiScanPhotoItemsDetected": {
+    "placeholders": {
+      "index": {},
+      "count": {}
+    }
+  },
+  "multiScanPhotoItemsUnclear": "Photo {index}: {count} items detected / {unclear} unclear",
+  "@multiScanPhotoItemsUnclear": {
+    "placeholders": {
+      "index": {},
+      "count": {},
+      "unclear": {}
+    }
+  },
+  "multiScanNoReadableItems": "Photo {index}: no readable menu items detected",
+  "@multiScanNoReadableItems": {
+    "placeholders": {
+      "index": {}
+    }
+  },
+  "multiScanTotalSummary": "Total {total} detected / {unique} after duplicate removal",
+  "@multiScanTotalSummary": {
+    "placeholders": {
+      "total": {},
+      "unique": {}
+    }
+  },
+  "multiScanTotalSummaryWithDuplicates": "Total {total} detected / {unique} after duplicate removal ({duplicates} duplicates)",
+  "@multiScanTotalSummaryWithDuplicates": {
+    "placeholders": {
+      "total": {},
+      "unique": {},
+      "duplicates": {}
+    }
+  },
+  "multiScanTotalPhotoCount": "Total photo count: {count}",
+  "@multiScanTotalPhotoCount": {
+    "placeholders": {
+      "count": {}
+    }
+  },
+  "multiScanDetailsUnavailable": "Photo analysis details are unavailable, but the merged result is safe to view."
 }

--- a/lib/l10n/app_hi.arb
+++ b/lib/l10n/app_hi.arb
@@ -377,5 +377,49 @@
   "premiumStartCta": "Start Premium",
   "premiumGuestSectionTitle": "Connect your account before purchasing Premium in guest mode",
   "premiumGuestSectionMessage": "Premium subscriptions are linked to your account so purchases can be restored and used across devices.",
-  "premiumGuestConvertButton": "Convert account to continue"
+  "premiumGuestConvertButton": "Convert account to continue",
+  "multiScanSummaryTitle": "Multi-scan summary",
+  "multiScanPhotoItemsDetected": "Photo {index}: {count} items detected",
+  "@multiScanPhotoItemsDetected": {
+    "placeholders": {
+      "index": {},
+      "count": {}
+    }
+  },
+  "multiScanPhotoItemsUnclear": "Photo {index}: {count} items detected / {unclear} unclear",
+  "@multiScanPhotoItemsUnclear": {
+    "placeholders": {
+      "index": {},
+      "count": {},
+      "unclear": {}
+    }
+  },
+  "multiScanNoReadableItems": "Photo {index}: no readable menu items detected",
+  "@multiScanNoReadableItems": {
+    "placeholders": {
+      "index": {}
+    }
+  },
+  "multiScanTotalSummary": "Total {total} detected / {unique} after duplicate removal",
+  "@multiScanTotalSummary": {
+    "placeholders": {
+      "total": {},
+      "unique": {}
+    }
+  },
+  "multiScanTotalSummaryWithDuplicates": "Total {total} detected / {unique} after duplicate removal ({duplicates} duplicates)",
+  "@multiScanTotalSummaryWithDuplicates": {
+    "placeholders": {
+      "total": {},
+      "unique": {},
+      "duplicates": {}
+    }
+  },
+  "multiScanTotalPhotoCount": "Total photo count: {count}",
+  "@multiScanTotalPhotoCount": {
+    "placeholders": {
+      "count": {}
+    }
+  },
+  "multiScanDetailsUnavailable": "Photo analysis details are unavailable, but the merged result is safe to view."
 }

--- a/lib/l10n/app_id.arb
+++ b/lib/l10n/app_id.arb
@@ -377,5 +377,49 @@
   "premiumStartCta": "Start Premium",
   "premiumGuestSectionTitle": "Connect your account before purchasing Premium in guest mode",
   "premiumGuestSectionMessage": "Premium subscriptions are linked to your account so purchases can be restored and used across devices.",
-  "premiumGuestConvertButton": "Convert account to continue"
+  "premiumGuestConvertButton": "Convert account to continue",
+  "multiScanSummaryTitle": "Multi-scan summary",
+  "multiScanPhotoItemsDetected": "Photo {index}: {count} items detected",
+  "@multiScanPhotoItemsDetected": {
+    "placeholders": {
+      "index": {},
+      "count": {}
+    }
+  },
+  "multiScanPhotoItemsUnclear": "Photo {index}: {count} items detected / {unclear} unclear",
+  "@multiScanPhotoItemsUnclear": {
+    "placeholders": {
+      "index": {},
+      "count": {},
+      "unclear": {}
+    }
+  },
+  "multiScanNoReadableItems": "Photo {index}: no readable menu items detected",
+  "@multiScanNoReadableItems": {
+    "placeholders": {
+      "index": {}
+    }
+  },
+  "multiScanTotalSummary": "Total {total} detected / {unique} after duplicate removal",
+  "@multiScanTotalSummary": {
+    "placeholders": {
+      "total": {},
+      "unique": {}
+    }
+  },
+  "multiScanTotalSummaryWithDuplicates": "Total {total} detected / {unique} after duplicate removal ({duplicates} duplicates)",
+  "@multiScanTotalSummaryWithDuplicates": {
+    "placeholders": {
+      "total": {},
+      "unique": {},
+      "duplicates": {}
+    }
+  },
+  "multiScanTotalPhotoCount": "Total photo count: {count}",
+  "@multiScanTotalPhotoCount": {
+    "placeholders": {
+      "count": {}
+    }
+  },
+  "multiScanDetailsUnavailable": "Photo analysis details are unavailable, but the merged result is safe to view."
 }

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -377,5 +377,49 @@
   "premiumStartCta": "Start Premium",
   "premiumGuestSectionTitle": "Connect your account before purchasing Premium in guest mode",
   "premiumGuestSectionMessage": "Premium subscriptions are linked to your account so purchases can be restored and used across devices.",
-  "premiumGuestConvertButton": "Convert account to continue"
+  "premiumGuestConvertButton": "Convert account to continue",
+  "multiScanSummaryTitle": "Multi-scan summary",
+  "multiScanPhotoItemsDetected": "Photo {index}: {count} items detected",
+  "@multiScanPhotoItemsDetected": {
+    "placeholders": {
+      "index": {},
+      "count": {}
+    }
+  },
+  "multiScanPhotoItemsUnclear": "Photo {index}: {count} items detected / {unclear} unclear",
+  "@multiScanPhotoItemsUnclear": {
+    "placeholders": {
+      "index": {},
+      "count": {},
+      "unclear": {}
+    }
+  },
+  "multiScanNoReadableItems": "Photo {index}: no readable menu items detected",
+  "@multiScanNoReadableItems": {
+    "placeholders": {
+      "index": {}
+    }
+  },
+  "multiScanTotalSummary": "Total {total} detected / {unique} after duplicate removal",
+  "@multiScanTotalSummary": {
+    "placeholders": {
+      "total": {},
+      "unique": {}
+    }
+  },
+  "multiScanTotalSummaryWithDuplicates": "Total {total} detected / {unique} after duplicate removal ({duplicates} duplicates)",
+  "@multiScanTotalSummaryWithDuplicates": {
+    "placeholders": {
+      "total": {},
+      "unique": {},
+      "duplicates": {}
+    }
+  },
+  "multiScanTotalPhotoCount": "Total photo count: {count}",
+  "@multiScanTotalPhotoCount": {
+    "placeholders": {
+      "count": {}
+    }
+  },
+  "multiScanDetailsUnavailable": "Photo analysis details are unavailable, but the merged result is safe to view."
 }

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -377,5 +377,49 @@
   "premiumStartCta": "프리미엄 시작",
   "premiumGuestSectionTitle": "게스트 모드에서는 프리미엄 구매 전에 계정 연결이 필요해요",
   "premiumGuestSectionMessage": "프리미엄 구독은 계정에 연결되어 구매 내역 복원과 기기 간 유지가 가능해요.",
-  "premiumGuestConvertButton": "계정 전환 후 계속"
+  "premiumGuestConvertButton": "계정 전환 후 계속",
+  "multiScanSummaryTitle": "멀티 스캔 요약",
+  "multiScanPhotoItemsDetected": "사진 {index}: 메뉴 {count}개 감지",
+  "@multiScanPhotoItemsDetected": {
+    "placeholders": {
+      "index": {},
+      "count": {}
+    }
+  },
+  "multiScanPhotoItemsUnclear": "사진 {index}: 메뉴 {count}개 감지 / 읽기 어려움 {unclear}개",
+  "@multiScanPhotoItemsUnclear": {
+    "placeholders": {
+      "index": {},
+      "count": {},
+      "unclear": {}
+    }
+  },
+  "multiScanNoReadableItems": "사진 {index}: 읽을 수 있는 메뉴가 감지되지 않음",
+  "@multiScanNoReadableItems": {
+    "placeholders": {
+      "index": {}
+    }
+  },
+  "multiScanTotalSummary": "총 {total}개 감지 / 중복 제거 후 {unique}개",
+  "@multiScanTotalSummary": {
+    "placeholders": {
+      "total": {},
+      "unique": {}
+    }
+  },
+  "multiScanTotalSummaryWithDuplicates": "총 {total}개 감지 / 중복 제거 후 {unique}개 (중복 {duplicates}개)",
+  "@multiScanTotalSummaryWithDuplicates": {
+    "placeholders": {
+      "total": {},
+      "unique": {},
+      "duplicates": {}
+    }
+  },
+  "multiScanTotalPhotoCount": "총 사진 수: {count}",
+  "@multiScanTotalPhotoCount": {
+    "placeholders": {
+      "count": {}
+    }
+  },
+  "multiScanDetailsUnavailable": "사진별 분석 정보는 없지만 병합 결과는 안전하게 볼 수 있습니다."
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -2088,6 +2088,55 @@ abstract class AppLocalizations {
   /// **'AI returned an empty stream response.'**
   String get result_aiEmptyStreamResponse;
 
+
+  /// No description provided for @multiScanSummaryTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Multi-scan summary'**
+  String get multiScanSummaryTitle;
+
+  /// No description provided for @multiScanPhotoItemsDetected.
+  ///
+  /// In en, this message translates to:
+  /// **'Photo {index}: {count} items detected'**
+  String multiScanPhotoItemsDetected(Object index, Object count);
+
+  /// No description provided for @multiScanPhotoItemsUnclear.
+  ///
+  /// In en, this message translates to:
+  /// **'Photo {index}: {count} items detected / {unclear} unclear'**
+  String multiScanPhotoItemsUnclear(Object index, Object count, Object unclear);
+
+  /// No description provided for @multiScanNoReadableItems.
+  ///
+  /// In en, this message translates to:
+  /// **'Photo {index}: no readable menu items detected'**
+  String multiScanNoReadableItems(Object index);
+
+  /// No description provided for @multiScanTotalSummary.
+  ///
+  /// In en, this message translates to:
+  /// **'Total {total} detected / {unique} after duplicate removal'**
+  String multiScanTotalSummary(Object total, Object unique);
+
+  /// No description provided for @multiScanTotalSummaryWithDuplicates.
+  ///
+  /// In en, this message translates to:
+  /// **'Total {total} detected / {unique} after duplicate removal ({duplicates} duplicates)'**
+  String multiScanTotalSummaryWithDuplicates(Object total, Object unique, Object duplicates);
+
+  /// No description provided for @multiScanTotalPhotoCount.
+  ///
+  /// In en, this message translates to:
+  /// **'Total photo count: {count}'**
+  String multiScanTotalPhotoCount(Object count);
+
+  /// No description provided for @multiScanDetailsUnavailable.
+  ///
+  /// In en, this message translates to:
+  /// **'Photo analysis details are unavailable, but the merged result is safe to view.'**
+  String get multiScanDetailsUnavailable;
+
   /// No description provided for @tts_orderPhraseTitle.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_ar.dart
+++ b/lib/l10n/app_localizations_ar.dart
@@ -1002,6 +1002,43 @@ class AppLocalizationsAr extends AppLocalizations {
   @override
   String get result_aiEmptyStreamResponse => 'أرجع الذكاء الاصطناعي استجابة تدفق فارغة.';
 
+
+  @override
+  String get multiScanSummaryTitle => 'Multi-scan summary';
+
+  @override
+  String multiScanPhotoItemsDetected(Object index, Object count) {
+    return 'Photo $index: $count items detected';
+  }
+
+  @override
+  String multiScanPhotoItemsUnclear(Object index, Object count, Object unclear) {
+    return 'Photo $index: $count items detected / $unclear unclear';
+  }
+
+  @override
+  String multiScanNoReadableItems(Object index) {
+    return 'Photo $index: no readable menu items detected';
+  }
+
+  @override
+  String multiScanTotalSummary(Object total, Object unique) {
+    return 'Total $total detected / $unique after duplicate removal';
+  }
+
+  @override
+  String multiScanTotalSummaryWithDuplicates(Object total, Object unique, Object duplicates) {
+    return 'Total $total detected / $unique after duplicate removal ($duplicates duplicates)';
+  }
+
+  @override
+  String multiScanTotalPhotoCount(Object count) {
+    return 'Total photo count: $count';
+  }
+
+  @override
+  String get multiScanDetailsUnavailable => 'Photo analysis details are unavailable, but the merged result is safe to view.';
+
   @override
   String get tts_orderPhraseTitle => 'أنشئ عبارة ترتيب';
 

--- a/lib/l10n/app_localizations_bn.dart
+++ b/lib/l10n/app_localizations_bn.dart
@@ -1002,6 +1002,43 @@ class AppLocalizationsBn extends AppLocalizations {
   @override
   String get result_aiEmptyStreamResponse => 'এআই একটি খালি স্ট্রিম প্রতিক্রিয়া ফেরত দিয়েছে.';
 
+
+  @override
+  String get multiScanSummaryTitle => 'Multi-scan summary';
+
+  @override
+  String multiScanPhotoItemsDetected(Object index, Object count) {
+    return 'Photo $index: $count items detected';
+  }
+
+  @override
+  String multiScanPhotoItemsUnclear(Object index, Object count, Object unclear) {
+    return 'Photo $index: $count items detected / $unclear unclear';
+  }
+
+  @override
+  String multiScanNoReadableItems(Object index) {
+    return 'Photo $index: no readable menu items detected';
+  }
+
+  @override
+  String multiScanTotalSummary(Object total, Object unique) {
+    return 'Total $total detected / $unique after duplicate removal';
+  }
+
+  @override
+  String multiScanTotalSummaryWithDuplicates(Object total, Object unique, Object duplicates) {
+    return 'Total $total detected / $unique after duplicate removal ($duplicates duplicates)';
+  }
+
+  @override
+  String multiScanTotalPhotoCount(Object count) {
+    return 'Total photo count: $count';
+  }
+
+  @override
+  String get multiScanDetailsUnavailable => 'Photo analysis details are unavailable, but the merged result is safe to view.';
+
   @override
   String get tts_orderPhraseTitle => 'অর্ডার করার বাক্যাংশ তৈরি করুন';
 

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -1002,6 +1002,43 @@ class AppLocalizationsDe extends AppLocalizations {
   @override
   String get result_aiEmptyStreamResponse => 'Die KI lieferte eine leere Streaming-Antwort.';
 
+
+  @override
+  String get multiScanSummaryTitle => 'Multi-scan summary';
+
+  @override
+  String multiScanPhotoItemsDetected(Object index, Object count) {
+    return 'Photo $index: $count items detected';
+  }
+
+  @override
+  String multiScanPhotoItemsUnclear(Object index, Object count, Object unclear) {
+    return 'Photo $index: $count items detected / $unclear unclear';
+  }
+
+  @override
+  String multiScanNoReadableItems(Object index) {
+    return 'Photo $index: no readable menu items detected';
+  }
+
+  @override
+  String multiScanTotalSummary(Object total, Object unique) {
+    return 'Total $total detected / $unique after duplicate removal';
+  }
+
+  @override
+  String multiScanTotalSummaryWithDuplicates(Object total, Object unique, Object duplicates) {
+    return 'Total $total detected / $unique after duplicate removal ($duplicates duplicates)';
+  }
+
+  @override
+  String multiScanTotalPhotoCount(Object count) {
+    return 'Total photo count: $count';
+  }
+
+  @override
+  String get multiScanDetailsUnavailable => 'Photo analysis details are unavailable, but the merged result is safe to view.';
+
   @override
   String get tts_orderPhraseTitle => 'Erstelle eine Bestellformulierung';
 

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1002,6 +1002,43 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String get result_aiEmptyStreamResponse => 'AI returned an empty stream response.';
 
+
+  @override
+  String get multiScanSummaryTitle => 'Multi-scan summary';
+
+  @override
+  String multiScanPhotoItemsDetected(Object index, Object count) {
+    return 'Photo $index: $count items detected';
+  }
+
+  @override
+  String multiScanPhotoItemsUnclear(Object index, Object count, Object unclear) {
+    return 'Photo $index: $count items detected / $unclear unclear';
+  }
+
+  @override
+  String multiScanNoReadableItems(Object index) {
+    return 'Photo $index: no readable menu items detected';
+  }
+
+  @override
+  String multiScanTotalSummary(Object total, Object unique) {
+    return 'Total $total detected / $unique after duplicate removal';
+  }
+
+  @override
+  String multiScanTotalSummaryWithDuplicates(Object total, Object unique, Object duplicates) {
+    return 'Total $total detected / $unique after duplicate removal ($duplicates duplicates)';
+  }
+
+  @override
+  String multiScanTotalPhotoCount(Object count) {
+    return 'Total photo count: $count';
+  }
+
+  @override
+  String get multiScanDetailsUnavailable => 'Photo analysis details are unavailable, but the merged result is safe to view.';
+
   @override
   String get tts_orderPhraseTitle => 'Create ordering phrase';
 

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -1002,6 +1002,43 @@ class AppLocalizationsEs extends AppLocalizations {
   @override
   String get result_aiEmptyStreamResponse => 'La IA devolvió una respuesta de flujo vacía.';
 
+
+  @override
+  String get multiScanSummaryTitle => 'Multi-scan summary';
+
+  @override
+  String multiScanPhotoItemsDetected(Object index, Object count) {
+    return 'Photo $index: $count items detected';
+  }
+
+  @override
+  String multiScanPhotoItemsUnclear(Object index, Object count, Object unclear) {
+    return 'Photo $index: $count items detected / $unclear unclear';
+  }
+
+  @override
+  String multiScanNoReadableItems(Object index) {
+    return 'Photo $index: no readable menu items detected';
+  }
+
+  @override
+  String multiScanTotalSummary(Object total, Object unique) {
+    return 'Total $total detected / $unique after duplicate removal';
+  }
+
+  @override
+  String multiScanTotalSummaryWithDuplicates(Object total, Object unique, Object duplicates) {
+    return 'Total $total detected / $unique after duplicate removal ($duplicates duplicates)';
+  }
+
+  @override
+  String multiScanTotalPhotoCount(Object count) {
+    return 'Total photo count: $count';
+  }
+
+  @override
+  String get multiScanDetailsUnavailable => 'Photo analysis details are unavailable, but the merged result is safe to view.';
+
   @override
   String get tts_orderPhraseTitle => 'Crear frase de pedido';
 

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -1002,6 +1002,43 @@ class AppLocalizationsFr extends AppLocalizations {
   @override
   String get result_aiEmptyStreamResponse => 'L\'IA a renvoyé une réponse en streaming vide.';
 
+
+  @override
+  String get multiScanSummaryTitle => 'Multi-scan summary';
+
+  @override
+  String multiScanPhotoItemsDetected(Object index, Object count) {
+    return 'Photo $index: $count items detected';
+  }
+
+  @override
+  String multiScanPhotoItemsUnclear(Object index, Object count, Object unclear) {
+    return 'Photo $index: $count items detected / $unclear unclear';
+  }
+
+  @override
+  String multiScanNoReadableItems(Object index) {
+    return 'Photo $index: no readable menu items detected';
+  }
+
+  @override
+  String multiScanTotalSummary(Object total, Object unique) {
+    return 'Total $total detected / $unique after duplicate removal';
+  }
+
+  @override
+  String multiScanTotalSummaryWithDuplicates(Object total, Object unique, Object duplicates) {
+    return 'Total $total detected / $unique after duplicate removal ($duplicates duplicates)';
+  }
+
+  @override
+  String multiScanTotalPhotoCount(Object count) {
+    return 'Total photo count: $count';
+  }
+
+  @override
+  String get multiScanDetailsUnavailable => 'Photo analysis details are unavailable, but the merged result is safe to view.';
+
   @override
   String get tts_orderPhraseTitle => 'Créer une phrase de commande';
 

--- a/lib/l10n/app_localizations_hi.dart
+++ b/lib/l10n/app_localizations_hi.dart
@@ -1002,6 +1002,43 @@ class AppLocalizationsHi extends AppLocalizations {
   @override
   String get result_aiEmptyStreamResponse => 'AI ने एक खाली स्ट्रीम प्रतिक्रिया लौटाई।';
 
+
+  @override
+  String get multiScanSummaryTitle => 'Multi-scan summary';
+
+  @override
+  String multiScanPhotoItemsDetected(Object index, Object count) {
+    return 'Photo $index: $count items detected';
+  }
+
+  @override
+  String multiScanPhotoItemsUnclear(Object index, Object count, Object unclear) {
+    return 'Photo $index: $count items detected / $unclear unclear';
+  }
+
+  @override
+  String multiScanNoReadableItems(Object index) {
+    return 'Photo $index: no readable menu items detected';
+  }
+
+  @override
+  String multiScanTotalSummary(Object total, Object unique) {
+    return 'Total $total detected / $unique after duplicate removal';
+  }
+
+  @override
+  String multiScanTotalSummaryWithDuplicates(Object total, Object unique, Object duplicates) {
+    return 'Total $total detected / $unique after duplicate removal ($duplicates duplicates)';
+  }
+
+  @override
+  String multiScanTotalPhotoCount(Object count) {
+    return 'Total photo count: $count';
+  }
+
+  @override
+  String get multiScanDetailsUnavailable => 'Photo analysis details are unavailable, but the merged result is safe to view.';
+
   @override
   String get tts_orderPhraseTitle => 'आदेश देने का वाक्यांश बनाएं';
 

--- a/lib/l10n/app_localizations_id.dart
+++ b/lib/l10n/app_localizations_id.dart
@@ -1002,6 +1002,43 @@ class AppLocalizationsId extends AppLocalizations {
   @override
   String get result_aiEmptyStreamResponse => 'Respons streaming kosong dari AI.';
 
+
+  @override
+  String get multiScanSummaryTitle => 'Multi-scan summary';
+
+  @override
+  String multiScanPhotoItemsDetected(Object index, Object count) {
+    return 'Photo $index: $count items detected';
+  }
+
+  @override
+  String multiScanPhotoItemsUnclear(Object index, Object count, Object unclear) {
+    return 'Photo $index: $count items detected / $unclear unclear';
+  }
+
+  @override
+  String multiScanNoReadableItems(Object index) {
+    return 'Photo $index: no readable menu items detected';
+  }
+
+  @override
+  String multiScanTotalSummary(Object total, Object unique) {
+    return 'Total $total detected / $unique after duplicate removal';
+  }
+
+  @override
+  String multiScanTotalSummaryWithDuplicates(Object total, Object unique, Object duplicates) {
+    return 'Total $total detected / $unique after duplicate removal ($duplicates duplicates)';
+  }
+
+  @override
+  String multiScanTotalPhotoCount(Object count) {
+    return 'Total photo count: $count';
+  }
+
+  @override
+  String get multiScanDetailsUnavailable => 'Photo analysis details are unavailable, but the merged result is safe to view.';
+
   @override
   String get tts_orderPhraseTitle => 'Buat frasa pemesanan';
 

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -1002,6 +1002,43 @@ class AppLocalizationsJa extends AppLocalizations {
   @override
   String get result_aiEmptyStreamResponse => 'AIが空のストリームレスポンスを返しました。';
 
+
+  @override
+  String get multiScanSummaryTitle => 'Multi-scan summary';
+
+  @override
+  String multiScanPhotoItemsDetected(Object index, Object count) {
+    return 'Photo $index: $count items detected';
+  }
+
+  @override
+  String multiScanPhotoItemsUnclear(Object index, Object count, Object unclear) {
+    return 'Photo $index: $count items detected / $unclear unclear';
+  }
+
+  @override
+  String multiScanNoReadableItems(Object index) {
+    return 'Photo $index: no readable menu items detected';
+  }
+
+  @override
+  String multiScanTotalSummary(Object total, Object unique) {
+    return 'Total $total detected / $unique after duplicate removal';
+  }
+
+  @override
+  String multiScanTotalSummaryWithDuplicates(Object total, Object unique, Object duplicates) {
+    return 'Total $total detected / $unique after duplicate removal ($duplicates duplicates)';
+  }
+
+  @override
+  String multiScanTotalPhotoCount(Object count) {
+    return 'Total photo count: $count';
+  }
+
+  @override
+  String get multiScanDetailsUnavailable => 'Photo analysis details are unavailable, but the merged result is safe to view.';
+
   @override
   String get tts_orderPhraseTitle => '注文フレーズを作成する';
 

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -1002,6 +1002,43 @@ class AppLocalizationsKo extends AppLocalizations {
   @override
   String get result_aiEmptyStreamResponse => 'AI가 빈 스트림 응답을 반환했습니다.';
 
+
+  @override
+  String get multiScanSummaryTitle => '멀티 스캔 요약';
+
+  @override
+  String multiScanPhotoItemsDetected(Object index, Object count) {
+    return '사진 $index: 메뉴 $count개 감지';
+  }
+
+  @override
+  String multiScanPhotoItemsUnclear(Object index, Object count, Object unclear) {
+    return '사진 $index: 메뉴 $count개 감지 / 읽기 어려움 $unclear개';
+  }
+
+  @override
+  String multiScanNoReadableItems(Object index) {
+    return '사진 $index: 읽을 수 있는 메뉴가 감지되지 않음';
+  }
+
+  @override
+  String multiScanTotalSummary(Object total, Object unique) {
+    return '총 $total개 감지 / 중복 제거 후 $unique개';
+  }
+
+  @override
+  String multiScanTotalSummaryWithDuplicates(Object total, Object unique, Object duplicates) {
+    return '총 $total개 감지 / 중복 제거 후 $unique개 (중복 $duplicates개)';
+  }
+
+  @override
+  String multiScanTotalPhotoCount(Object count) {
+    return '총 사진 수: $count';
+  }
+
+  @override
+  String get multiScanDetailsUnavailable => '사진별 분석 정보는 없지만 병합 결과는 안전하게 볼 수 있습니다.';
+
   @override
   String get tts_orderPhraseTitle => '주문 문구 생성';
 

--- a/lib/l10n/app_localizations_mr.dart
+++ b/lib/l10n/app_localizations_mr.dart
@@ -1002,6 +1002,43 @@ class AppLocalizationsMr extends AppLocalizations {
   @override
   String get result_aiEmptyStreamResponse => 'एआयने रिक्त स्ट्रीम प्रतिसाद परत केला.';
 
+
+  @override
+  String get multiScanSummaryTitle => 'Multi-scan summary';
+
+  @override
+  String multiScanPhotoItemsDetected(Object index, Object count) {
+    return 'Photo $index: $count items detected';
+  }
+
+  @override
+  String multiScanPhotoItemsUnclear(Object index, Object count, Object unclear) {
+    return 'Photo $index: $count items detected / $unclear unclear';
+  }
+
+  @override
+  String multiScanNoReadableItems(Object index) {
+    return 'Photo $index: no readable menu items detected';
+  }
+
+  @override
+  String multiScanTotalSummary(Object total, Object unique) {
+    return 'Total $total detected / $unique after duplicate removal';
+  }
+
+  @override
+  String multiScanTotalSummaryWithDuplicates(Object total, Object unique, Object duplicates) {
+    return 'Total $total detected / $unique after duplicate removal ($duplicates duplicates)';
+  }
+
+  @override
+  String multiScanTotalPhotoCount(Object count) {
+    return 'Total photo count: $count';
+  }
+
+  @override
+  String get multiScanDetailsUnavailable => 'Photo analysis details are unavailable, but the merged result is safe to view.';
+
   @override
   String get tts_orderPhraseTitle => 'ऑर्डर करण्याचे वाक्य तयार करा';
 

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -1002,6 +1002,43 @@ class AppLocalizationsPt extends AppLocalizations {
   @override
   String get result_aiEmptyStreamResponse => 'A IA retornou uma resposta de fluxo vazia.';
 
+
+  @override
+  String get multiScanSummaryTitle => 'Multi-scan summary';
+
+  @override
+  String multiScanPhotoItemsDetected(Object index, Object count) {
+    return 'Photo $index: $count items detected';
+  }
+
+  @override
+  String multiScanPhotoItemsUnclear(Object index, Object count, Object unclear) {
+    return 'Photo $index: $count items detected / $unclear unclear';
+  }
+
+  @override
+  String multiScanNoReadableItems(Object index) {
+    return 'Photo $index: no readable menu items detected';
+  }
+
+  @override
+  String multiScanTotalSummary(Object total, Object unique) {
+    return 'Total $total detected / $unique after duplicate removal';
+  }
+
+  @override
+  String multiScanTotalSummaryWithDuplicates(Object total, Object unique, Object duplicates) {
+    return 'Total $total detected / $unique after duplicate removal ($duplicates duplicates)';
+  }
+
+  @override
+  String multiScanTotalPhotoCount(Object count) {
+    return 'Total photo count: $count';
+  }
+
+  @override
+  String get multiScanDetailsUnavailable => 'Photo analysis details are unavailable, but the merged result is safe to view.';
+
   @override
   String get tts_orderPhraseTitle => 'Criar frase de encomenda';
 
@@ -2090,6 +2127,43 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String get result_aiEmptyStreamResponse => 'A IA retornou uma resposta de stream vazia.';
+
+
+  @override
+  String get multiScanSummaryTitle => 'Multi-scan summary';
+
+  @override
+  String multiScanPhotoItemsDetected(Object index, Object count) {
+    return 'Photo $index: $count items detected';
+  }
+
+  @override
+  String multiScanPhotoItemsUnclear(Object index, Object count, Object unclear) {
+    return 'Photo $index: $count items detected / $unclear unclear';
+  }
+
+  @override
+  String multiScanNoReadableItems(Object index) {
+    return 'Photo $index: no readable menu items detected';
+  }
+
+  @override
+  String multiScanTotalSummary(Object total, Object unique) {
+    return 'Total $total detected / $unique after duplicate removal';
+  }
+
+  @override
+  String multiScanTotalSummaryWithDuplicates(Object total, Object unique, Object duplicates) {
+    return 'Total $total detected / $unique after duplicate removal ($duplicates duplicates)';
+  }
+
+  @override
+  String multiScanTotalPhotoCount(Object count) {
+    return 'Total photo count: $count';
+  }
+
+  @override
+  String get multiScanDetailsUnavailable => 'Photo analysis details are unavailable, but the merged result is safe to view.';
 
   @override
   String get tts_orderPhraseTitle => 'Crie uma frase de pedido';

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -1002,6 +1002,43 @@ class AppLocalizationsRu extends AppLocalizations {
   @override
   String get result_aiEmptyStreamResponse => 'AI вернул пустой ответ потока.';
 
+
+  @override
+  String get multiScanSummaryTitle => 'Multi-scan summary';
+
+  @override
+  String multiScanPhotoItemsDetected(Object index, Object count) {
+    return 'Photo $index: $count items detected';
+  }
+
+  @override
+  String multiScanPhotoItemsUnclear(Object index, Object count, Object unclear) {
+    return 'Photo $index: $count items detected / $unclear unclear';
+  }
+
+  @override
+  String multiScanNoReadableItems(Object index) {
+    return 'Photo $index: no readable menu items detected';
+  }
+
+  @override
+  String multiScanTotalSummary(Object total, Object unique) {
+    return 'Total $total detected / $unique after duplicate removal';
+  }
+
+  @override
+  String multiScanTotalSummaryWithDuplicates(Object total, Object unique, Object duplicates) {
+    return 'Total $total detected / $unique after duplicate removal ($duplicates duplicates)';
+  }
+
+  @override
+  String multiScanTotalPhotoCount(Object count) {
+    return 'Total photo count: $count';
+  }
+
+  @override
+  String get multiScanDetailsUnavailable => 'Photo analysis details are unavailable, but the merged result is safe to view.';
+
   @override
   String get tts_orderPhraseTitle => 'Создайте фразу для заказа';
 

--- a/lib/l10n/app_localizations_te.dart
+++ b/lib/l10n/app_localizations_te.dart
@@ -1002,6 +1002,43 @@ class AppLocalizationsTe extends AppLocalizations {
   @override
   String get result_aiEmptyStreamResponse => 'AI ద్వారా ఖాళీ స్ట్రీమ్ ప్రతిస్పందన వచ్చింది.';
 
+
+  @override
+  String get multiScanSummaryTitle => 'Multi-scan summary';
+
+  @override
+  String multiScanPhotoItemsDetected(Object index, Object count) {
+    return 'Photo $index: $count items detected';
+  }
+
+  @override
+  String multiScanPhotoItemsUnclear(Object index, Object count, Object unclear) {
+    return 'Photo $index: $count items detected / $unclear unclear';
+  }
+
+  @override
+  String multiScanNoReadableItems(Object index) {
+    return 'Photo $index: no readable menu items detected';
+  }
+
+  @override
+  String multiScanTotalSummary(Object total, Object unique) {
+    return 'Total $total detected / $unique after duplicate removal';
+  }
+
+  @override
+  String multiScanTotalSummaryWithDuplicates(Object total, Object unique, Object duplicates) {
+    return 'Total $total detected / $unique after duplicate removal ($duplicates duplicates)';
+  }
+
+  @override
+  String multiScanTotalPhotoCount(Object count) {
+    return 'Total photo count: $count';
+  }
+
+  @override
+  String get multiScanDetailsUnavailable => 'Photo analysis details are unavailable, but the merged result is safe to view.';
+
   @override
   String get tts_orderPhraseTitle => 'ఆర్డరింగ్ కోసం పదబంధం సృష్టించండి';
 

--- a/lib/l10n/app_localizations_th.dart
+++ b/lib/l10n/app_localizations_th.dart
@@ -1002,6 +1002,43 @@ class AppLocalizationsTh extends AppLocalizations {
   @override
   String get result_aiEmptyStreamResponse => 'ระบบ AI ส่งคืนการตอบกลับแบบสตรีมที่ว่างเปล่าแล้ว';
 
+
+  @override
+  String get multiScanSummaryTitle => 'Multi-scan summary';
+
+  @override
+  String multiScanPhotoItemsDetected(Object index, Object count) {
+    return 'Photo $index: $count items detected';
+  }
+
+  @override
+  String multiScanPhotoItemsUnclear(Object index, Object count, Object unclear) {
+    return 'Photo $index: $count items detected / $unclear unclear';
+  }
+
+  @override
+  String multiScanNoReadableItems(Object index) {
+    return 'Photo $index: no readable menu items detected';
+  }
+
+  @override
+  String multiScanTotalSummary(Object total, Object unique) {
+    return 'Total $total detected / $unique after duplicate removal';
+  }
+
+  @override
+  String multiScanTotalSummaryWithDuplicates(Object total, Object unique, Object duplicates) {
+    return 'Total $total detected / $unique after duplicate removal ($duplicates duplicates)';
+  }
+
+  @override
+  String multiScanTotalPhotoCount(Object count) {
+    return 'Total photo count: $count';
+  }
+
+  @override
+  String get multiScanDetailsUnavailable => 'Photo analysis details are unavailable, but the merged result is safe to view.';
+
   @override
   String get tts_orderPhraseTitle => 'สร้างประโยคสำหรับการสั่งซื้อ';
 

--- a/lib/l10n/app_localizations_tr.dart
+++ b/lib/l10n/app_localizations_tr.dart
@@ -1002,6 +1002,43 @@ class AppLocalizationsTr extends AppLocalizations {
   @override
   String get result_aiEmptyStreamResponse => 'Yapay zekâ boş bir akış yanıtı döndürdü.';
 
+
+  @override
+  String get multiScanSummaryTitle => 'Multi-scan summary';
+
+  @override
+  String multiScanPhotoItemsDetected(Object index, Object count) {
+    return 'Photo $index: $count items detected';
+  }
+
+  @override
+  String multiScanPhotoItemsUnclear(Object index, Object count, Object unclear) {
+    return 'Photo $index: $count items detected / $unclear unclear';
+  }
+
+  @override
+  String multiScanNoReadableItems(Object index) {
+    return 'Photo $index: no readable menu items detected';
+  }
+
+  @override
+  String multiScanTotalSummary(Object total, Object unique) {
+    return 'Total $total detected / $unique after duplicate removal';
+  }
+
+  @override
+  String multiScanTotalSummaryWithDuplicates(Object total, Object unique, Object duplicates) {
+    return 'Total $total detected / $unique after duplicate removal ($duplicates duplicates)';
+  }
+
+  @override
+  String multiScanTotalPhotoCount(Object count) {
+    return 'Total photo count: $count';
+  }
+
+  @override
+  String get multiScanDetailsUnavailable => 'Photo analysis details are unavailable, but the merged result is safe to view.';
+
   @override
   String get tts_orderPhraseTitle => 'Sipariş cümlesi oluşturun';
 

--- a/lib/l10n/app_localizations_ur.dart
+++ b/lib/l10n/app_localizations_ur.dart
@@ -1002,6 +1002,43 @@ class AppLocalizationsUr extends AppLocalizations {
   @override
   String get result_aiEmptyStreamResponse => 'AI نے خالی اسٹریم کا جواب واپس کیا۔';
 
+
+  @override
+  String get multiScanSummaryTitle => 'Multi-scan summary';
+
+  @override
+  String multiScanPhotoItemsDetected(Object index, Object count) {
+    return 'Photo $index: $count items detected';
+  }
+
+  @override
+  String multiScanPhotoItemsUnclear(Object index, Object count, Object unclear) {
+    return 'Photo $index: $count items detected / $unclear unclear';
+  }
+
+  @override
+  String multiScanNoReadableItems(Object index) {
+    return 'Photo $index: no readable menu items detected';
+  }
+
+  @override
+  String multiScanTotalSummary(Object total, Object unique) {
+    return 'Total $total detected / $unique after duplicate removal';
+  }
+
+  @override
+  String multiScanTotalSummaryWithDuplicates(Object total, Object unique, Object duplicates) {
+    return 'Total $total detected / $unique after duplicate removal ($duplicates duplicates)';
+  }
+
+  @override
+  String multiScanTotalPhotoCount(Object count) {
+    return 'Total photo count: $count';
+  }
+
+  @override
+  String get multiScanDetailsUnavailable => 'Photo analysis details are unavailable, but the merged result is safe to view.';
+
   @override
   String get tts_orderPhraseTitle => 'آرڈر کرنے کا جملہ بنائیں';
 

--- a/lib/l10n/app_localizations_vi.dart
+++ b/lib/l10n/app_localizations_vi.dart
@@ -1002,6 +1002,43 @@ class AppLocalizationsVi extends AppLocalizations {
   @override
   String get result_aiEmptyStreamResponse => 'AI đã trả về một phản hồi luồng trống.';
 
+
+  @override
+  String get multiScanSummaryTitle => 'Multi-scan summary';
+
+  @override
+  String multiScanPhotoItemsDetected(Object index, Object count) {
+    return 'Photo $index: $count items detected';
+  }
+
+  @override
+  String multiScanPhotoItemsUnclear(Object index, Object count, Object unclear) {
+    return 'Photo $index: $count items detected / $unclear unclear';
+  }
+
+  @override
+  String multiScanNoReadableItems(Object index) {
+    return 'Photo $index: no readable menu items detected';
+  }
+
+  @override
+  String multiScanTotalSummary(Object total, Object unique) {
+    return 'Total $total detected / $unique after duplicate removal';
+  }
+
+  @override
+  String multiScanTotalSummaryWithDuplicates(Object total, Object unique, Object duplicates) {
+    return 'Total $total detected / $unique after duplicate removal ($duplicates duplicates)';
+  }
+
+  @override
+  String multiScanTotalPhotoCount(Object count) {
+    return 'Total photo count: $count';
+  }
+
+  @override
+  String get multiScanDetailsUnavailable => 'Photo analysis details are unavailable, but the merged result is safe to view.';
+
   @override
   String get tts_orderPhraseTitle => 'Tạo cụm từ để đặt hàng';
 

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -1002,6 +1002,43 @@ class AppLocalizationsZh extends AppLocalizations {
   @override
   String get result_aiEmptyStreamResponse => 'AI 返回了空的流响应。';
 
+
+  @override
+  String get multiScanSummaryTitle => 'Multi-scan summary';
+
+  @override
+  String multiScanPhotoItemsDetected(Object index, Object count) {
+    return 'Photo $index: $count items detected';
+  }
+
+  @override
+  String multiScanPhotoItemsUnclear(Object index, Object count, Object unclear) {
+    return 'Photo $index: $count items detected / $unclear unclear';
+  }
+
+  @override
+  String multiScanNoReadableItems(Object index) {
+    return 'Photo $index: no readable menu items detected';
+  }
+
+  @override
+  String multiScanTotalSummary(Object total, Object unique) {
+    return 'Total $total detected / $unique after duplicate removal';
+  }
+
+  @override
+  String multiScanTotalSummaryWithDuplicates(Object total, Object unique, Object duplicates) {
+    return 'Total $total detected / $unique after duplicate removal ($duplicates duplicates)';
+  }
+
+  @override
+  String multiScanTotalPhotoCount(Object count) {
+    return 'Total photo count: $count';
+  }
+
+  @override
+  String get multiScanDetailsUnavailable => 'Photo analysis details are unavailable, but the merged result is safe to view.';
+
   @override
   String get tts_orderPhraseTitle => '创建订购短语';
 
@@ -2091,6 +2128,43 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
   @override
   String get result_aiEmptyStreamResponse => 'AI 返回了一个空的流响应。';
 
+
+  @override
+  String get multiScanSummaryTitle => 'Multi-scan summary';
+
+  @override
+  String multiScanPhotoItemsDetected(Object index, Object count) {
+    return 'Photo $index: $count items detected';
+  }
+
+  @override
+  String multiScanPhotoItemsUnclear(Object index, Object count, Object unclear) {
+    return 'Photo $index: $count items detected / $unclear unclear';
+  }
+
+  @override
+  String multiScanNoReadableItems(Object index) {
+    return 'Photo $index: no readable menu items detected';
+  }
+
+  @override
+  String multiScanTotalSummary(Object total, Object unique) {
+    return 'Total $total detected / $unique after duplicate removal';
+  }
+
+  @override
+  String multiScanTotalSummaryWithDuplicates(Object total, Object unique, Object duplicates) {
+    return 'Total $total detected / $unique after duplicate removal ($duplicates duplicates)';
+  }
+
+  @override
+  String multiScanTotalPhotoCount(Object count) {
+    return 'Total photo count: $count';
+  }
+
+  @override
+  String get multiScanDetailsUnavailable => 'Photo analysis details are unavailable, but the merged result is safe to view.';
+
   @override
   String get tts_orderPhraseTitle => '创建订购短语';
 
@@ -3179,6 +3253,43 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String get result_aiEmptyStreamResponse => 'AI 返回了空的串流回應。';
+
+
+  @override
+  String get multiScanSummaryTitle => 'Multi-scan summary';
+
+  @override
+  String multiScanPhotoItemsDetected(Object index, Object count) {
+    return 'Photo $index: $count items detected';
+  }
+
+  @override
+  String multiScanPhotoItemsUnclear(Object index, Object count, Object unclear) {
+    return 'Photo $index: $count items detected / $unclear unclear';
+  }
+
+  @override
+  String multiScanNoReadableItems(Object index) {
+    return 'Photo $index: no readable menu items detected';
+  }
+
+  @override
+  String multiScanTotalSummary(Object total, Object unique) {
+    return 'Total $total detected / $unique after duplicate removal';
+  }
+
+  @override
+  String multiScanTotalSummaryWithDuplicates(Object total, Object unique, Object duplicates) {
+    return 'Total $total detected / $unique after duplicate removal ($duplicates duplicates)';
+  }
+
+  @override
+  String multiScanTotalPhotoCount(Object count) {
+    return 'Total photo count: $count';
+  }
+
+  @override
+  String get multiScanDetailsUnavailable => 'Photo analysis details are unavailable, but the merged result is safe to view.';
 
   @override
   String get tts_orderPhraseTitle => '創建下單用語';

--- a/lib/l10n/app_mr.arb
+++ b/lib/l10n/app_mr.arb
@@ -377,5 +377,49 @@
   "premiumStartCta": "Start Premium",
   "premiumGuestSectionTitle": "Connect your account before purchasing Premium in guest mode",
   "premiumGuestSectionMessage": "Premium subscriptions are linked to your account so purchases can be restored and used across devices.",
-  "premiumGuestConvertButton": "Convert account to continue"
+  "premiumGuestConvertButton": "Convert account to continue",
+  "multiScanSummaryTitle": "Multi-scan summary",
+  "multiScanPhotoItemsDetected": "Photo {index}: {count} items detected",
+  "@multiScanPhotoItemsDetected": {
+    "placeholders": {
+      "index": {},
+      "count": {}
+    }
+  },
+  "multiScanPhotoItemsUnclear": "Photo {index}: {count} items detected / {unclear} unclear",
+  "@multiScanPhotoItemsUnclear": {
+    "placeholders": {
+      "index": {},
+      "count": {},
+      "unclear": {}
+    }
+  },
+  "multiScanNoReadableItems": "Photo {index}: no readable menu items detected",
+  "@multiScanNoReadableItems": {
+    "placeholders": {
+      "index": {}
+    }
+  },
+  "multiScanTotalSummary": "Total {total} detected / {unique} after duplicate removal",
+  "@multiScanTotalSummary": {
+    "placeholders": {
+      "total": {},
+      "unique": {}
+    }
+  },
+  "multiScanTotalSummaryWithDuplicates": "Total {total} detected / {unique} after duplicate removal ({duplicates} duplicates)",
+  "@multiScanTotalSummaryWithDuplicates": {
+    "placeholders": {
+      "total": {},
+      "unique": {},
+      "duplicates": {}
+    }
+  },
+  "multiScanTotalPhotoCount": "Total photo count: {count}",
+  "@multiScanTotalPhotoCount": {
+    "placeholders": {
+      "count": {}
+    }
+  },
+  "multiScanDetailsUnavailable": "Photo analysis details are unavailable, but the merged result is safe to view."
 }

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -377,5 +377,49 @@
   "premiumStartCta": "Start Premium",
   "premiumGuestSectionTitle": "Connect your account before purchasing Premium in guest mode",
   "premiumGuestSectionMessage": "Premium subscriptions are linked to your account so purchases can be restored and used across devices.",
-  "premiumGuestConvertButton": "Convert account to continue"
+  "premiumGuestConvertButton": "Convert account to continue",
+  "multiScanSummaryTitle": "Multi-scan summary",
+  "multiScanPhotoItemsDetected": "Photo {index}: {count} items detected",
+  "@multiScanPhotoItemsDetected": {
+    "placeholders": {
+      "index": {},
+      "count": {}
+    }
+  },
+  "multiScanPhotoItemsUnclear": "Photo {index}: {count} items detected / {unclear} unclear",
+  "@multiScanPhotoItemsUnclear": {
+    "placeholders": {
+      "index": {},
+      "count": {},
+      "unclear": {}
+    }
+  },
+  "multiScanNoReadableItems": "Photo {index}: no readable menu items detected",
+  "@multiScanNoReadableItems": {
+    "placeholders": {
+      "index": {}
+    }
+  },
+  "multiScanTotalSummary": "Total {total} detected / {unique} after duplicate removal",
+  "@multiScanTotalSummary": {
+    "placeholders": {
+      "total": {},
+      "unique": {}
+    }
+  },
+  "multiScanTotalSummaryWithDuplicates": "Total {total} detected / {unique} after duplicate removal ({duplicates} duplicates)",
+  "@multiScanTotalSummaryWithDuplicates": {
+    "placeholders": {
+      "total": {},
+      "unique": {},
+      "duplicates": {}
+    }
+  },
+  "multiScanTotalPhotoCount": "Total photo count: {count}",
+  "@multiScanTotalPhotoCount": {
+    "placeholders": {
+      "count": {}
+    }
+  },
+  "multiScanDetailsUnavailable": "Photo analysis details are unavailable, but the merged result is safe to view."
 }

--- a/lib/l10n/app_pt_BR.arb
+++ b/lib/l10n/app_pt_BR.arb
@@ -377,5 +377,49 @@
   "premiumStartCta": "Start Premium",
   "premiumGuestSectionTitle": "Connect your account before purchasing Premium in guest mode",
   "premiumGuestSectionMessage": "Premium subscriptions are linked to your account so purchases can be restored and used across devices.",
-  "premiumGuestConvertButton": "Convert account to continue"
+  "premiumGuestConvertButton": "Convert account to continue",
+  "multiScanSummaryTitle": "Multi-scan summary",
+  "multiScanPhotoItemsDetected": "Photo {index}: {count} items detected",
+  "@multiScanPhotoItemsDetected": {
+    "placeholders": {
+      "index": {},
+      "count": {}
+    }
+  },
+  "multiScanPhotoItemsUnclear": "Photo {index}: {count} items detected / {unclear} unclear",
+  "@multiScanPhotoItemsUnclear": {
+    "placeholders": {
+      "index": {},
+      "count": {},
+      "unclear": {}
+    }
+  },
+  "multiScanNoReadableItems": "Photo {index}: no readable menu items detected",
+  "@multiScanNoReadableItems": {
+    "placeholders": {
+      "index": {}
+    }
+  },
+  "multiScanTotalSummary": "Total {total} detected / {unique} after duplicate removal",
+  "@multiScanTotalSummary": {
+    "placeholders": {
+      "total": {},
+      "unique": {}
+    }
+  },
+  "multiScanTotalSummaryWithDuplicates": "Total {total} detected / {unique} after duplicate removal ({duplicates} duplicates)",
+  "@multiScanTotalSummaryWithDuplicates": {
+    "placeholders": {
+      "total": {},
+      "unique": {},
+      "duplicates": {}
+    }
+  },
+  "multiScanTotalPhotoCount": "Total photo count: {count}",
+  "@multiScanTotalPhotoCount": {
+    "placeholders": {
+      "count": {}
+    }
+  },
+  "multiScanDetailsUnavailable": "Photo analysis details are unavailable, but the merged result is safe to view."
 }

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -377,5 +377,49 @@
   "premiumStartCta": "Start Premium",
   "premiumGuestSectionTitle": "Connect your account before purchasing Premium in guest mode",
   "premiumGuestSectionMessage": "Premium subscriptions are linked to your account so purchases can be restored and used across devices.",
-  "premiumGuestConvertButton": "Convert account to continue"
+  "premiumGuestConvertButton": "Convert account to continue",
+  "multiScanSummaryTitle": "Multi-scan summary",
+  "multiScanPhotoItemsDetected": "Photo {index}: {count} items detected",
+  "@multiScanPhotoItemsDetected": {
+    "placeholders": {
+      "index": {},
+      "count": {}
+    }
+  },
+  "multiScanPhotoItemsUnclear": "Photo {index}: {count} items detected / {unclear} unclear",
+  "@multiScanPhotoItemsUnclear": {
+    "placeholders": {
+      "index": {},
+      "count": {},
+      "unclear": {}
+    }
+  },
+  "multiScanNoReadableItems": "Photo {index}: no readable menu items detected",
+  "@multiScanNoReadableItems": {
+    "placeholders": {
+      "index": {}
+    }
+  },
+  "multiScanTotalSummary": "Total {total} detected / {unique} after duplicate removal",
+  "@multiScanTotalSummary": {
+    "placeholders": {
+      "total": {},
+      "unique": {}
+    }
+  },
+  "multiScanTotalSummaryWithDuplicates": "Total {total} detected / {unique} after duplicate removal ({duplicates} duplicates)",
+  "@multiScanTotalSummaryWithDuplicates": {
+    "placeholders": {
+      "total": {},
+      "unique": {},
+      "duplicates": {}
+    }
+  },
+  "multiScanTotalPhotoCount": "Total photo count: {count}",
+  "@multiScanTotalPhotoCount": {
+    "placeholders": {
+      "count": {}
+    }
+  },
+  "multiScanDetailsUnavailable": "Photo analysis details are unavailable, but the merged result is safe to view."
 }

--- a/lib/l10n/app_te.arb
+++ b/lib/l10n/app_te.arb
@@ -377,5 +377,49 @@
   "premiumStartCta": "Start Premium",
   "premiumGuestSectionTitle": "Connect your account before purchasing Premium in guest mode",
   "premiumGuestSectionMessage": "Premium subscriptions are linked to your account so purchases can be restored and used across devices.",
-  "premiumGuestConvertButton": "Convert account to continue"
+  "premiumGuestConvertButton": "Convert account to continue",
+  "multiScanSummaryTitle": "Multi-scan summary",
+  "multiScanPhotoItemsDetected": "Photo {index}: {count} items detected",
+  "@multiScanPhotoItemsDetected": {
+    "placeholders": {
+      "index": {},
+      "count": {}
+    }
+  },
+  "multiScanPhotoItemsUnclear": "Photo {index}: {count} items detected / {unclear} unclear",
+  "@multiScanPhotoItemsUnclear": {
+    "placeholders": {
+      "index": {},
+      "count": {},
+      "unclear": {}
+    }
+  },
+  "multiScanNoReadableItems": "Photo {index}: no readable menu items detected",
+  "@multiScanNoReadableItems": {
+    "placeholders": {
+      "index": {}
+    }
+  },
+  "multiScanTotalSummary": "Total {total} detected / {unique} after duplicate removal",
+  "@multiScanTotalSummary": {
+    "placeholders": {
+      "total": {},
+      "unique": {}
+    }
+  },
+  "multiScanTotalSummaryWithDuplicates": "Total {total} detected / {unique} after duplicate removal ({duplicates} duplicates)",
+  "@multiScanTotalSummaryWithDuplicates": {
+    "placeholders": {
+      "total": {},
+      "unique": {},
+      "duplicates": {}
+    }
+  },
+  "multiScanTotalPhotoCount": "Total photo count: {count}",
+  "@multiScanTotalPhotoCount": {
+    "placeholders": {
+      "count": {}
+    }
+  },
+  "multiScanDetailsUnavailable": "Photo analysis details are unavailable, but the merged result is safe to view."
 }

--- a/lib/l10n/app_th.arb
+++ b/lib/l10n/app_th.arb
@@ -377,5 +377,49 @@
   "premiumStartCta": "Start Premium",
   "premiumGuestSectionTitle": "Connect your account before purchasing Premium in guest mode",
   "premiumGuestSectionMessage": "Premium subscriptions are linked to your account so purchases can be restored and used across devices.",
-  "premiumGuestConvertButton": "Convert account to continue"
+  "premiumGuestConvertButton": "Convert account to continue",
+  "multiScanSummaryTitle": "Multi-scan summary",
+  "multiScanPhotoItemsDetected": "Photo {index}: {count} items detected",
+  "@multiScanPhotoItemsDetected": {
+    "placeholders": {
+      "index": {},
+      "count": {}
+    }
+  },
+  "multiScanPhotoItemsUnclear": "Photo {index}: {count} items detected / {unclear} unclear",
+  "@multiScanPhotoItemsUnclear": {
+    "placeholders": {
+      "index": {},
+      "count": {},
+      "unclear": {}
+    }
+  },
+  "multiScanNoReadableItems": "Photo {index}: no readable menu items detected",
+  "@multiScanNoReadableItems": {
+    "placeholders": {
+      "index": {}
+    }
+  },
+  "multiScanTotalSummary": "Total {total} detected / {unique} after duplicate removal",
+  "@multiScanTotalSummary": {
+    "placeholders": {
+      "total": {},
+      "unique": {}
+    }
+  },
+  "multiScanTotalSummaryWithDuplicates": "Total {total} detected / {unique} after duplicate removal ({duplicates} duplicates)",
+  "@multiScanTotalSummaryWithDuplicates": {
+    "placeholders": {
+      "total": {},
+      "unique": {},
+      "duplicates": {}
+    }
+  },
+  "multiScanTotalPhotoCount": "Total photo count: {count}",
+  "@multiScanTotalPhotoCount": {
+    "placeholders": {
+      "count": {}
+    }
+  },
+  "multiScanDetailsUnavailable": "Photo analysis details are unavailable, but the merged result is safe to view."
 }

--- a/lib/l10n/app_tr.arb
+++ b/lib/l10n/app_tr.arb
@@ -377,5 +377,49 @@
   "premiumStartCta": "Start Premium",
   "premiumGuestSectionTitle": "Connect your account before purchasing Premium in guest mode",
   "premiumGuestSectionMessage": "Premium subscriptions are linked to your account so purchases can be restored and used across devices.",
-  "premiumGuestConvertButton": "Convert account to continue"
+  "premiumGuestConvertButton": "Convert account to continue",
+  "multiScanSummaryTitle": "Multi-scan summary",
+  "multiScanPhotoItemsDetected": "Photo {index}: {count} items detected",
+  "@multiScanPhotoItemsDetected": {
+    "placeholders": {
+      "index": {},
+      "count": {}
+    }
+  },
+  "multiScanPhotoItemsUnclear": "Photo {index}: {count} items detected / {unclear} unclear",
+  "@multiScanPhotoItemsUnclear": {
+    "placeholders": {
+      "index": {},
+      "count": {},
+      "unclear": {}
+    }
+  },
+  "multiScanNoReadableItems": "Photo {index}: no readable menu items detected",
+  "@multiScanNoReadableItems": {
+    "placeholders": {
+      "index": {}
+    }
+  },
+  "multiScanTotalSummary": "Total {total} detected / {unique} after duplicate removal",
+  "@multiScanTotalSummary": {
+    "placeholders": {
+      "total": {},
+      "unique": {}
+    }
+  },
+  "multiScanTotalSummaryWithDuplicates": "Total {total} detected / {unique} after duplicate removal ({duplicates} duplicates)",
+  "@multiScanTotalSummaryWithDuplicates": {
+    "placeholders": {
+      "total": {},
+      "unique": {},
+      "duplicates": {}
+    }
+  },
+  "multiScanTotalPhotoCount": "Total photo count: {count}",
+  "@multiScanTotalPhotoCount": {
+    "placeholders": {
+      "count": {}
+    }
+  },
+  "multiScanDetailsUnavailable": "Photo analysis details are unavailable, but the merged result is safe to view."
 }

--- a/lib/l10n/app_ur.arb
+++ b/lib/l10n/app_ur.arb
@@ -377,5 +377,49 @@
   "premiumStartCta": "Start Premium",
   "premiumGuestSectionTitle": "Connect your account before purchasing Premium in guest mode",
   "premiumGuestSectionMessage": "Premium subscriptions are linked to your account so purchases can be restored and used across devices.",
-  "premiumGuestConvertButton": "Convert account to continue"
+  "premiumGuestConvertButton": "Convert account to continue",
+  "multiScanSummaryTitle": "Multi-scan summary",
+  "multiScanPhotoItemsDetected": "Photo {index}: {count} items detected",
+  "@multiScanPhotoItemsDetected": {
+    "placeholders": {
+      "index": {},
+      "count": {}
+    }
+  },
+  "multiScanPhotoItemsUnclear": "Photo {index}: {count} items detected / {unclear} unclear",
+  "@multiScanPhotoItemsUnclear": {
+    "placeholders": {
+      "index": {},
+      "count": {},
+      "unclear": {}
+    }
+  },
+  "multiScanNoReadableItems": "Photo {index}: no readable menu items detected",
+  "@multiScanNoReadableItems": {
+    "placeholders": {
+      "index": {}
+    }
+  },
+  "multiScanTotalSummary": "Total {total} detected / {unique} after duplicate removal",
+  "@multiScanTotalSummary": {
+    "placeholders": {
+      "total": {},
+      "unique": {}
+    }
+  },
+  "multiScanTotalSummaryWithDuplicates": "Total {total} detected / {unique} after duplicate removal ({duplicates} duplicates)",
+  "@multiScanTotalSummaryWithDuplicates": {
+    "placeholders": {
+      "total": {},
+      "unique": {},
+      "duplicates": {}
+    }
+  },
+  "multiScanTotalPhotoCount": "Total photo count: {count}",
+  "@multiScanTotalPhotoCount": {
+    "placeholders": {
+      "count": {}
+    }
+  },
+  "multiScanDetailsUnavailable": "Photo analysis details are unavailable, but the merged result is safe to view."
 }

--- a/lib/l10n/app_vi.arb
+++ b/lib/l10n/app_vi.arb
@@ -377,5 +377,49 @@
   "premiumStartCta": "Start Premium",
   "premiumGuestSectionTitle": "Connect your account before purchasing Premium in guest mode",
   "premiumGuestSectionMessage": "Premium subscriptions are linked to your account so purchases can be restored and used across devices.",
-  "premiumGuestConvertButton": "Convert account to continue"
+  "premiumGuestConvertButton": "Convert account to continue",
+  "multiScanSummaryTitle": "Multi-scan summary",
+  "multiScanPhotoItemsDetected": "Photo {index}: {count} items detected",
+  "@multiScanPhotoItemsDetected": {
+    "placeholders": {
+      "index": {},
+      "count": {}
+    }
+  },
+  "multiScanPhotoItemsUnclear": "Photo {index}: {count} items detected / {unclear} unclear",
+  "@multiScanPhotoItemsUnclear": {
+    "placeholders": {
+      "index": {},
+      "count": {},
+      "unclear": {}
+    }
+  },
+  "multiScanNoReadableItems": "Photo {index}: no readable menu items detected",
+  "@multiScanNoReadableItems": {
+    "placeholders": {
+      "index": {}
+    }
+  },
+  "multiScanTotalSummary": "Total {total} detected / {unique} after duplicate removal",
+  "@multiScanTotalSummary": {
+    "placeholders": {
+      "total": {},
+      "unique": {}
+    }
+  },
+  "multiScanTotalSummaryWithDuplicates": "Total {total} detected / {unique} after duplicate removal ({duplicates} duplicates)",
+  "@multiScanTotalSummaryWithDuplicates": {
+    "placeholders": {
+      "total": {},
+      "unique": {},
+      "duplicates": {}
+    }
+  },
+  "multiScanTotalPhotoCount": "Total photo count: {count}",
+  "@multiScanTotalPhotoCount": {
+    "placeholders": {
+      "count": {}
+    }
+  },
+  "multiScanDetailsUnavailable": "Photo analysis details are unavailable, but the merged result is safe to view."
 }

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -377,5 +377,49 @@
   "premiumStartCta": "Start Premium",
   "premiumGuestSectionTitle": "Connect your account before purchasing Premium in guest mode",
   "premiumGuestSectionMessage": "Premium subscriptions are linked to your account so purchases can be restored and used across devices.",
-  "premiumGuestConvertButton": "Convert account to continue"
+  "premiumGuestConvertButton": "Convert account to continue",
+  "multiScanSummaryTitle": "Multi-scan summary",
+  "multiScanPhotoItemsDetected": "Photo {index}: {count} items detected",
+  "@multiScanPhotoItemsDetected": {
+    "placeholders": {
+      "index": {},
+      "count": {}
+    }
+  },
+  "multiScanPhotoItemsUnclear": "Photo {index}: {count} items detected / {unclear} unclear",
+  "@multiScanPhotoItemsUnclear": {
+    "placeholders": {
+      "index": {},
+      "count": {},
+      "unclear": {}
+    }
+  },
+  "multiScanNoReadableItems": "Photo {index}: no readable menu items detected",
+  "@multiScanNoReadableItems": {
+    "placeholders": {
+      "index": {}
+    }
+  },
+  "multiScanTotalSummary": "Total {total} detected / {unique} after duplicate removal",
+  "@multiScanTotalSummary": {
+    "placeholders": {
+      "total": {},
+      "unique": {}
+    }
+  },
+  "multiScanTotalSummaryWithDuplicates": "Total {total} detected / {unique} after duplicate removal ({duplicates} duplicates)",
+  "@multiScanTotalSummaryWithDuplicates": {
+    "placeholders": {
+      "total": {},
+      "unique": {},
+      "duplicates": {}
+    }
+  },
+  "multiScanTotalPhotoCount": "Total photo count: {count}",
+  "@multiScanTotalPhotoCount": {
+    "placeholders": {
+      "count": {}
+    }
+  },
+  "multiScanDetailsUnavailable": "Photo analysis details are unavailable, but the merged result is safe to view."
 }

--- a/lib/l10n/app_zh_Hans.arb
+++ b/lib/l10n/app_zh_Hans.arb
@@ -377,5 +377,49 @@
   "premiumStartCta": "Start Premium",
   "premiumGuestSectionTitle": "Connect your account before purchasing Premium in guest mode",
   "premiumGuestSectionMessage": "Premium subscriptions are linked to your account so purchases can be restored and used across devices.",
-  "premiumGuestConvertButton": "Convert account to continue"
+  "premiumGuestConvertButton": "Convert account to continue",
+  "multiScanSummaryTitle": "Multi-scan summary",
+  "multiScanPhotoItemsDetected": "Photo {index}: {count} items detected",
+  "@multiScanPhotoItemsDetected": {
+    "placeholders": {
+      "index": {},
+      "count": {}
+    }
+  },
+  "multiScanPhotoItemsUnclear": "Photo {index}: {count} items detected / {unclear} unclear",
+  "@multiScanPhotoItemsUnclear": {
+    "placeholders": {
+      "index": {},
+      "count": {},
+      "unclear": {}
+    }
+  },
+  "multiScanNoReadableItems": "Photo {index}: no readable menu items detected",
+  "@multiScanNoReadableItems": {
+    "placeholders": {
+      "index": {}
+    }
+  },
+  "multiScanTotalSummary": "Total {total} detected / {unique} after duplicate removal",
+  "@multiScanTotalSummary": {
+    "placeholders": {
+      "total": {},
+      "unique": {}
+    }
+  },
+  "multiScanTotalSummaryWithDuplicates": "Total {total} detected / {unique} after duplicate removal ({duplicates} duplicates)",
+  "@multiScanTotalSummaryWithDuplicates": {
+    "placeholders": {
+      "total": {},
+      "unique": {},
+      "duplicates": {}
+    }
+  },
+  "multiScanTotalPhotoCount": "Total photo count: {count}",
+  "@multiScanTotalPhotoCount": {
+    "placeholders": {
+      "count": {}
+    }
+  },
+  "multiScanDetailsUnavailable": "Photo analysis details are unavailable, but the merged result is safe to view."
 }

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -377,5 +377,49 @@
   "premiumStartCta": "Start Premium",
   "premiumGuestSectionTitle": "Connect your account before purchasing Premium in guest mode",
   "premiumGuestSectionMessage": "Premium subscriptions are linked to your account so purchases can be restored and used across devices.",
-  "premiumGuestConvertButton": "Convert account to continue"
+  "premiumGuestConvertButton": "Convert account to continue",
+  "multiScanSummaryTitle": "Multi-scan summary",
+  "multiScanPhotoItemsDetected": "Photo {index}: {count} items detected",
+  "@multiScanPhotoItemsDetected": {
+    "placeholders": {
+      "index": {},
+      "count": {}
+    }
+  },
+  "multiScanPhotoItemsUnclear": "Photo {index}: {count} items detected / {unclear} unclear",
+  "@multiScanPhotoItemsUnclear": {
+    "placeholders": {
+      "index": {},
+      "count": {},
+      "unclear": {}
+    }
+  },
+  "multiScanNoReadableItems": "Photo {index}: no readable menu items detected",
+  "@multiScanNoReadableItems": {
+    "placeholders": {
+      "index": {}
+    }
+  },
+  "multiScanTotalSummary": "Total {total} detected / {unique} after duplicate removal",
+  "@multiScanTotalSummary": {
+    "placeholders": {
+      "total": {},
+      "unique": {}
+    }
+  },
+  "multiScanTotalSummaryWithDuplicates": "Total {total} detected / {unique} after duplicate removal ({duplicates} duplicates)",
+  "@multiScanTotalSummaryWithDuplicates": {
+    "placeholders": {
+      "total": {},
+      "unique": {},
+      "duplicates": {}
+    }
+  },
+  "multiScanTotalPhotoCount": "Total photo count: {count}",
+  "@multiScanTotalPhotoCount": {
+    "placeholders": {
+      "count": {}
+    }
+  },
+  "multiScanDetailsUnavailable": "Photo analysis details are unavailable, but the merged result is safe to view."
 }

--- a/lib/l10n/gen_l10n/app_localizations.dart
+++ b/lib/l10n/gen_l10n/app_localizations.dart
@@ -2088,6 +2088,55 @@ abstract class AppLocalizations {
   /// **'AI returned an empty stream response.'**
   String get result_aiEmptyStreamResponse;
 
+
+  /// No description provided for @multiScanSummaryTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Multi-scan summary'**
+  String get multiScanSummaryTitle;
+
+  /// No description provided for @multiScanPhotoItemsDetected.
+  ///
+  /// In en, this message translates to:
+  /// **'Photo {index}: {count} items detected'**
+  String multiScanPhotoItemsDetected(Object index, Object count);
+
+  /// No description provided for @multiScanPhotoItemsUnclear.
+  ///
+  /// In en, this message translates to:
+  /// **'Photo {index}: {count} items detected / {unclear} unclear'**
+  String multiScanPhotoItemsUnclear(Object index, Object count, Object unclear);
+
+  /// No description provided for @multiScanNoReadableItems.
+  ///
+  /// In en, this message translates to:
+  /// **'Photo {index}: no readable menu items detected'**
+  String multiScanNoReadableItems(Object index);
+
+  /// No description provided for @multiScanTotalSummary.
+  ///
+  /// In en, this message translates to:
+  /// **'Total {total} detected / {unique} after duplicate removal'**
+  String multiScanTotalSummary(Object total, Object unique);
+
+  /// No description provided for @multiScanTotalSummaryWithDuplicates.
+  ///
+  /// In en, this message translates to:
+  /// **'Total {total} detected / {unique} after duplicate removal ({duplicates} duplicates)'**
+  String multiScanTotalSummaryWithDuplicates(Object total, Object unique, Object duplicates);
+
+  /// No description provided for @multiScanTotalPhotoCount.
+  ///
+  /// In en, this message translates to:
+  /// **'Total photo count: {count}'**
+  String multiScanTotalPhotoCount(Object count);
+
+  /// No description provided for @multiScanDetailsUnavailable.
+  ///
+  /// In en, this message translates to:
+  /// **'Photo analysis details are unavailable, but the merged result is safe to view.'**
+  String get multiScanDetailsUnavailable;
+
   /// No description provided for @tts_orderPhraseTitle.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/gen_l10n/app_localizations_ar.dart
+++ b/lib/l10n/gen_l10n/app_localizations_ar.dart
@@ -1002,6 +1002,43 @@ class AppLocalizationsAr extends AppLocalizations {
   @override
   String get result_aiEmptyStreamResponse => 'أرجع الذكاء الاصطناعي استجابة تدفق فارغة.';
 
+
+  @override
+  String get multiScanSummaryTitle => 'Multi-scan summary';
+
+  @override
+  String multiScanPhotoItemsDetected(Object index, Object count) {
+    return 'Photo $index: $count items detected';
+  }
+
+  @override
+  String multiScanPhotoItemsUnclear(Object index, Object count, Object unclear) {
+    return 'Photo $index: $count items detected / $unclear unclear';
+  }
+
+  @override
+  String multiScanNoReadableItems(Object index) {
+    return 'Photo $index: no readable menu items detected';
+  }
+
+  @override
+  String multiScanTotalSummary(Object total, Object unique) {
+    return 'Total $total detected / $unique after duplicate removal';
+  }
+
+  @override
+  String multiScanTotalSummaryWithDuplicates(Object total, Object unique, Object duplicates) {
+    return 'Total $total detected / $unique after duplicate removal ($duplicates duplicates)';
+  }
+
+  @override
+  String multiScanTotalPhotoCount(Object count) {
+    return 'Total photo count: $count';
+  }
+
+  @override
+  String get multiScanDetailsUnavailable => 'Photo analysis details are unavailable, but the merged result is safe to view.';
+
   @override
   String get tts_orderPhraseTitle => 'أنشئ عبارة ترتيب';
 

--- a/lib/l10n/gen_l10n/app_localizations_bn.dart
+++ b/lib/l10n/gen_l10n/app_localizations_bn.dart
@@ -1002,6 +1002,43 @@ class AppLocalizationsBn extends AppLocalizations {
   @override
   String get result_aiEmptyStreamResponse => 'এআই একটি খালি স্ট্রিম প্রতিক্রিয়া ফেরত দিয়েছে.';
 
+
+  @override
+  String get multiScanSummaryTitle => 'Multi-scan summary';
+
+  @override
+  String multiScanPhotoItemsDetected(Object index, Object count) {
+    return 'Photo $index: $count items detected';
+  }
+
+  @override
+  String multiScanPhotoItemsUnclear(Object index, Object count, Object unclear) {
+    return 'Photo $index: $count items detected / $unclear unclear';
+  }
+
+  @override
+  String multiScanNoReadableItems(Object index) {
+    return 'Photo $index: no readable menu items detected';
+  }
+
+  @override
+  String multiScanTotalSummary(Object total, Object unique) {
+    return 'Total $total detected / $unique after duplicate removal';
+  }
+
+  @override
+  String multiScanTotalSummaryWithDuplicates(Object total, Object unique, Object duplicates) {
+    return 'Total $total detected / $unique after duplicate removal ($duplicates duplicates)';
+  }
+
+  @override
+  String multiScanTotalPhotoCount(Object count) {
+    return 'Total photo count: $count';
+  }
+
+  @override
+  String get multiScanDetailsUnavailable => 'Photo analysis details are unavailable, but the merged result is safe to view.';
+
   @override
   String get tts_orderPhraseTitle => 'অর্ডার করার বাক্যাংশ তৈরি করুন';
 

--- a/lib/l10n/gen_l10n/app_localizations_de.dart
+++ b/lib/l10n/gen_l10n/app_localizations_de.dart
@@ -1002,6 +1002,43 @@ class AppLocalizationsDe extends AppLocalizations {
   @override
   String get result_aiEmptyStreamResponse => 'Die KI lieferte eine leere Streaming-Antwort.';
 
+
+  @override
+  String get multiScanSummaryTitle => 'Multi-scan summary';
+
+  @override
+  String multiScanPhotoItemsDetected(Object index, Object count) {
+    return 'Photo $index: $count items detected';
+  }
+
+  @override
+  String multiScanPhotoItemsUnclear(Object index, Object count, Object unclear) {
+    return 'Photo $index: $count items detected / $unclear unclear';
+  }
+
+  @override
+  String multiScanNoReadableItems(Object index) {
+    return 'Photo $index: no readable menu items detected';
+  }
+
+  @override
+  String multiScanTotalSummary(Object total, Object unique) {
+    return 'Total $total detected / $unique after duplicate removal';
+  }
+
+  @override
+  String multiScanTotalSummaryWithDuplicates(Object total, Object unique, Object duplicates) {
+    return 'Total $total detected / $unique after duplicate removal ($duplicates duplicates)';
+  }
+
+  @override
+  String multiScanTotalPhotoCount(Object count) {
+    return 'Total photo count: $count';
+  }
+
+  @override
+  String get multiScanDetailsUnavailable => 'Photo analysis details are unavailable, but the merged result is safe to view.';
+
   @override
   String get tts_orderPhraseTitle => 'Erstelle eine Bestellformulierung';
 

--- a/lib/l10n/gen_l10n/app_localizations_en.dart
+++ b/lib/l10n/gen_l10n/app_localizations_en.dart
@@ -1002,6 +1002,43 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String get result_aiEmptyStreamResponse => 'AI returned an empty stream response.';
 
+
+  @override
+  String get multiScanSummaryTitle => 'Multi-scan summary';
+
+  @override
+  String multiScanPhotoItemsDetected(Object index, Object count) {
+    return 'Photo $index: $count items detected';
+  }
+
+  @override
+  String multiScanPhotoItemsUnclear(Object index, Object count, Object unclear) {
+    return 'Photo $index: $count items detected / $unclear unclear';
+  }
+
+  @override
+  String multiScanNoReadableItems(Object index) {
+    return 'Photo $index: no readable menu items detected';
+  }
+
+  @override
+  String multiScanTotalSummary(Object total, Object unique) {
+    return 'Total $total detected / $unique after duplicate removal';
+  }
+
+  @override
+  String multiScanTotalSummaryWithDuplicates(Object total, Object unique, Object duplicates) {
+    return 'Total $total detected / $unique after duplicate removal ($duplicates duplicates)';
+  }
+
+  @override
+  String multiScanTotalPhotoCount(Object count) {
+    return 'Total photo count: $count';
+  }
+
+  @override
+  String get multiScanDetailsUnavailable => 'Photo analysis details are unavailable, but the merged result is safe to view.';
+
   @override
   String get tts_orderPhraseTitle => 'Create ordering phrase';
 

--- a/lib/l10n/gen_l10n/app_localizations_es.dart
+++ b/lib/l10n/gen_l10n/app_localizations_es.dart
@@ -1002,6 +1002,43 @@ class AppLocalizationsEs extends AppLocalizations {
   @override
   String get result_aiEmptyStreamResponse => 'La IA devolvió una respuesta de flujo vacía.';
 
+
+  @override
+  String get multiScanSummaryTitle => 'Multi-scan summary';
+
+  @override
+  String multiScanPhotoItemsDetected(Object index, Object count) {
+    return 'Photo $index: $count items detected';
+  }
+
+  @override
+  String multiScanPhotoItemsUnclear(Object index, Object count, Object unclear) {
+    return 'Photo $index: $count items detected / $unclear unclear';
+  }
+
+  @override
+  String multiScanNoReadableItems(Object index) {
+    return 'Photo $index: no readable menu items detected';
+  }
+
+  @override
+  String multiScanTotalSummary(Object total, Object unique) {
+    return 'Total $total detected / $unique after duplicate removal';
+  }
+
+  @override
+  String multiScanTotalSummaryWithDuplicates(Object total, Object unique, Object duplicates) {
+    return 'Total $total detected / $unique after duplicate removal ($duplicates duplicates)';
+  }
+
+  @override
+  String multiScanTotalPhotoCount(Object count) {
+    return 'Total photo count: $count';
+  }
+
+  @override
+  String get multiScanDetailsUnavailable => 'Photo analysis details are unavailable, but the merged result is safe to view.';
+
   @override
   String get tts_orderPhraseTitle => 'Crear frase de pedido';
 

--- a/lib/l10n/gen_l10n/app_localizations_fr.dart
+++ b/lib/l10n/gen_l10n/app_localizations_fr.dart
@@ -1002,6 +1002,43 @@ class AppLocalizationsFr extends AppLocalizations {
   @override
   String get result_aiEmptyStreamResponse => 'L\'IA a renvoyé une réponse en streaming vide.';
 
+
+  @override
+  String get multiScanSummaryTitle => 'Multi-scan summary';
+
+  @override
+  String multiScanPhotoItemsDetected(Object index, Object count) {
+    return 'Photo $index: $count items detected';
+  }
+
+  @override
+  String multiScanPhotoItemsUnclear(Object index, Object count, Object unclear) {
+    return 'Photo $index: $count items detected / $unclear unclear';
+  }
+
+  @override
+  String multiScanNoReadableItems(Object index) {
+    return 'Photo $index: no readable menu items detected';
+  }
+
+  @override
+  String multiScanTotalSummary(Object total, Object unique) {
+    return 'Total $total detected / $unique after duplicate removal';
+  }
+
+  @override
+  String multiScanTotalSummaryWithDuplicates(Object total, Object unique, Object duplicates) {
+    return 'Total $total detected / $unique after duplicate removal ($duplicates duplicates)';
+  }
+
+  @override
+  String multiScanTotalPhotoCount(Object count) {
+    return 'Total photo count: $count';
+  }
+
+  @override
+  String get multiScanDetailsUnavailable => 'Photo analysis details are unavailable, but the merged result is safe to view.';
+
   @override
   String get tts_orderPhraseTitle => 'Créer une phrase de commande';
 

--- a/lib/l10n/gen_l10n/app_localizations_hi.dart
+++ b/lib/l10n/gen_l10n/app_localizations_hi.dart
@@ -1002,6 +1002,43 @@ class AppLocalizationsHi extends AppLocalizations {
   @override
   String get result_aiEmptyStreamResponse => 'AI ने एक खाली स्ट्रीम प्रतिक्रिया लौटाई।';
 
+
+  @override
+  String get multiScanSummaryTitle => 'Multi-scan summary';
+
+  @override
+  String multiScanPhotoItemsDetected(Object index, Object count) {
+    return 'Photo $index: $count items detected';
+  }
+
+  @override
+  String multiScanPhotoItemsUnclear(Object index, Object count, Object unclear) {
+    return 'Photo $index: $count items detected / $unclear unclear';
+  }
+
+  @override
+  String multiScanNoReadableItems(Object index) {
+    return 'Photo $index: no readable menu items detected';
+  }
+
+  @override
+  String multiScanTotalSummary(Object total, Object unique) {
+    return 'Total $total detected / $unique after duplicate removal';
+  }
+
+  @override
+  String multiScanTotalSummaryWithDuplicates(Object total, Object unique, Object duplicates) {
+    return 'Total $total detected / $unique after duplicate removal ($duplicates duplicates)';
+  }
+
+  @override
+  String multiScanTotalPhotoCount(Object count) {
+    return 'Total photo count: $count';
+  }
+
+  @override
+  String get multiScanDetailsUnavailable => 'Photo analysis details are unavailable, but the merged result is safe to view.';
+
   @override
   String get tts_orderPhraseTitle => 'आदेश देने का वाक्यांश बनाएं';
 

--- a/lib/l10n/gen_l10n/app_localizations_id.dart
+++ b/lib/l10n/gen_l10n/app_localizations_id.dart
@@ -1002,6 +1002,43 @@ class AppLocalizationsId extends AppLocalizations {
   @override
   String get result_aiEmptyStreamResponse => 'Respons streaming kosong dari AI.';
 
+
+  @override
+  String get multiScanSummaryTitle => 'Multi-scan summary';
+
+  @override
+  String multiScanPhotoItemsDetected(Object index, Object count) {
+    return 'Photo $index: $count items detected';
+  }
+
+  @override
+  String multiScanPhotoItemsUnclear(Object index, Object count, Object unclear) {
+    return 'Photo $index: $count items detected / $unclear unclear';
+  }
+
+  @override
+  String multiScanNoReadableItems(Object index) {
+    return 'Photo $index: no readable menu items detected';
+  }
+
+  @override
+  String multiScanTotalSummary(Object total, Object unique) {
+    return 'Total $total detected / $unique after duplicate removal';
+  }
+
+  @override
+  String multiScanTotalSummaryWithDuplicates(Object total, Object unique, Object duplicates) {
+    return 'Total $total detected / $unique after duplicate removal ($duplicates duplicates)';
+  }
+
+  @override
+  String multiScanTotalPhotoCount(Object count) {
+    return 'Total photo count: $count';
+  }
+
+  @override
+  String get multiScanDetailsUnavailable => 'Photo analysis details are unavailable, but the merged result is safe to view.';
+
   @override
   String get tts_orderPhraseTitle => 'Buat frasa pemesanan';
 

--- a/lib/l10n/gen_l10n/app_localizations_ja.dart
+++ b/lib/l10n/gen_l10n/app_localizations_ja.dart
@@ -1002,6 +1002,43 @@ class AppLocalizationsJa extends AppLocalizations {
   @override
   String get result_aiEmptyStreamResponse => 'AIが空のストリームレスポンスを返しました。';
 
+
+  @override
+  String get multiScanSummaryTitle => 'Multi-scan summary';
+
+  @override
+  String multiScanPhotoItemsDetected(Object index, Object count) {
+    return 'Photo $index: $count items detected';
+  }
+
+  @override
+  String multiScanPhotoItemsUnclear(Object index, Object count, Object unclear) {
+    return 'Photo $index: $count items detected / $unclear unclear';
+  }
+
+  @override
+  String multiScanNoReadableItems(Object index) {
+    return 'Photo $index: no readable menu items detected';
+  }
+
+  @override
+  String multiScanTotalSummary(Object total, Object unique) {
+    return 'Total $total detected / $unique after duplicate removal';
+  }
+
+  @override
+  String multiScanTotalSummaryWithDuplicates(Object total, Object unique, Object duplicates) {
+    return 'Total $total detected / $unique after duplicate removal ($duplicates duplicates)';
+  }
+
+  @override
+  String multiScanTotalPhotoCount(Object count) {
+    return 'Total photo count: $count';
+  }
+
+  @override
+  String get multiScanDetailsUnavailable => 'Photo analysis details are unavailable, but the merged result is safe to view.';
+
   @override
   String get tts_orderPhraseTitle => '注文フレーズを作成する';
 

--- a/lib/l10n/gen_l10n/app_localizations_ko.dart
+++ b/lib/l10n/gen_l10n/app_localizations_ko.dart
@@ -1002,6 +1002,43 @@ class AppLocalizationsKo extends AppLocalizations {
   @override
   String get result_aiEmptyStreamResponse => 'AI가 빈 스트림 응답을 반환했습니다.';
 
+
+  @override
+  String get multiScanSummaryTitle => '멀티 스캔 요약';
+
+  @override
+  String multiScanPhotoItemsDetected(Object index, Object count) {
+    return '사진 $index: 메뉴 $count개 감지';
+  }
+
+  @override
+  String multiScanPhotoItemsUnclear(Object index, Object count, Object unclear) {
+    return '사진 $index: 메뉴 $count개 감지 / 읽기 어려움 $unclear개';
+  }
+
+  @override
+  String multiScanNoReadableItems(Object index) {
+    return '사진 $index: 읽을 수 있는 메뉴가 감지되지 않음';
+  }
+
+  @override
+  String multiScanTotalSummary(Object total, Object unique) {
+    return '총 $total개 감지 / 중복 제거 후 $unique개';
+  }
+
+  @override
+  String multiScanTotalSummaryWithDuplicates(Object total, Object unique, Object duplicates) {
+    return '총 $total개 감지 / 중복 제거 후 $unique개 (중복 $duplicates개)';
+  }
+
+  @override
+  String multiScanTotalPhotoCount(Object count) {
+    return '총 사진 수: $count';
+  }
+
+  @override
+  String get multiScanDetailsUnavailable => '사진별 분석 정보는 없지만 병합 결과는 안전하게 볼 수 있습니다.';
+
   @override
   String get tts_orderPhraseTitle => '주문 문구 생성';
 

--- a/lib/l10n/gen_l10n/app_localizations_mr.dart
+++ b/lib/l10n/gen_l10n/app_localizations_mr.dart
@@ -1002,6 +1002,43 @@ class AppLocalizationsMr extends AppLocalizations {
   @override
   String get result_aiEmptyStreamResponse => 'एआयने रिक्त स्ट्रीम प्रतिसाद परत केला.';
 
+
+  @override
+  String get multiScanSummaryTitle => 'Multi-scan summary';
+
+  @override
+  String multiScanPhotoItemsDetected(Object index, Object count) {
+    return 'Photo $index: $count items detected';
+  }
+
+  @override
+  String multiScanPhotoItemsUnclear(Object index, Object count, Object unclear) {
+    return 'Photo $index: $count items detected / $unclear unclear';
+  }
+
+  @override
+  String multiScanNoReadableItems(Object index) {
+    return 'Photo $index: no readable menu items detected';
+  }
+
+  @override
+  String multiScanTotalSummary(Object total, Object unique) {
+    return 'Total $total detected / $unique after duplicate removal';
+  }
+
+  @override
+  String multiScanTotalSummaryWithDuplicates(Object total, Object unique, Object duplicates) {
+    return 'Total $total detected / $unique after duplicate removal ($duplicates duplicates)';
+  }
+
+  @override
+  String multiScanTotalPhotoCount(Object count) {
+    return 'Total photo count: $count';
+  }
+
+  @override
+  String get multiScanDetailsUnavailable => 'Photo analysis details are unavailable, but the merged result is safe to view.';
+
   @override
   String get tts_orderPhraseTitle => 'ऑर्डर करण्याचे वाक्य तयार करा';
 

--- a/lib/l10n/gen_l10n/app_localizations_pt.dart
+++ b/lib/l10n/gen_l10n/app_localizations_pt.dart
@@ -1002,6 +1002,43 @@ class AppLocalizationsPt extends AppLocalizations {
   @override
   String get result_aiEmptyStreamResponse => 'A IA retornou uma resposta de fluxo vazia.';
 
+
+  @override
+  String get multiScanSummaryTitle => 'Multi-scan summary';
+
+  @override
+  String multiScanPhotoItemsDetected(Object index, Object count) {
+    return 'Photo $index: $count items detected';
+  }
+
+  @override
+  String multiScanPhotoItemsUnclear(Object index, Object count, Object unclear) {
+    return 'Photo $index: $count items detected / $unclear unclear';
+  }
+
+  @override
+  String multiScanNoReadableItems(Object index) {
+    return 'Photo $index: no readable menu items detected';
+  }
+
+  @override
+  String multiScanTotalSummary(Object total, Object unique) {
+    return 'Total $total detected / $unique after duplicate removal';
+  }
+
+  @override
+  String multiScanTotalSummaryWithDuplicates(Object total, Object unique, Object duplicates) {
+    return 'Total $total detected / $unique after duplicate removal ($duplicates duplicates)';
+  }
+
+  @override
+  String multiScanTotalPhotoCount(Object count) {
+    return 'Total photo count: $count';
+  }
+
+  @override
+  String get multiScanDetailsUnavailable => 'Photo analysis details are unavailable, but the merged result is safe to view.';
+
   @override
   String get tts_orderPhraseTitle => 'Criar frase de encomenda';
 
@@ -2090,6 +2127,43 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String get result_aiEmptyStreamResponse => 'A IA retornou uma resposta de stream vazia.';
+
+
+  @override
+  String get multiScanSummaryTitle => 'Multi-scan summary';
+
+  @override
+  String multiScanPhotoItemsDetected(Object index, Object count) {
+    return 'Photo $index: $count items detected';
+  }
+
+  @override
+  String multiScanPhotoItemsUnclear(Object index, Object count, Object unclear) {
+    return 'Photo $index: $count items detected / $unclear unclear';
+  }
+
+  @override
+  String multiScanNoReadableItems(Object index) {
+    return 'Photo $index: no readable menu items detected';
+  }
+
+  @override
+  String multiScanTotalSummary(Object total, Object unique) {
+    return 'Total $total detected / $unique after duplicate removal';
+  }
+
+  @override
+  String multiScanTotalSummaryWithDuplicates(Object total, Object unique, Object duplicates) {
+    return 'Total $total detected / $unique after duplicate removal ($duplicates duplicates)';
+  }
+
+  @override
+  String multiScanTotalPhotoCount(Object count) {
+    return 'Total photo count: $count';
+  }
+
+  @override
+  String get multiScanDetailsUnavailable => 'Photo analysis details are unavailable, but the merged result is safe to view.';
 
   @override
   String get tts_orderPhraseTitle => 'Crie uma frase de pedido';

--- a/lib/l10n/gen_l10n/app_localizations_ru.dart
+++ b/lib/l10n/gen_l10n/app_localizations_ru.dart
@@ -1002,6 +1002,43 @@ class AppLocalizationsRu extends AppLocalizations {
   @override
   String get result_aiEmptyStreamResponse => 'AI вернул пустой ответ потока.';
 
+
+  @override
+  String get multiScanSummaryTitle => 'Multi-scan summary';
+
+  @override
+  String multiScanPhotoItemsDetected(Object index, Object count) {
+    return 'Photo $index: $count items detected';
+  }
+
+  @override
+  String multiScanPhotoItemsUnclear(Object index, Object count, Object unclear) {
+    return 'Photo $index: $count items detected / $unclear unclear';
+  }
+
+  @override
+  String multiScanNoReadableItems(Object index) {
+    return 'Photo $index: no readable menu items detected';
+  }
+
+  @override
+  String multiScanTotalSummary(Object total, Object unique) {
+    return 'Total $total detected / $unique after duplicate removal';
+  }
+
+  @override
+  String multiScanTotalSummaryWithDuplicates(Object total, Object unique, Object duplicates) {
+    return 'Total $total detected / $unique after duplicate removal ($duplicates duplicates)';
+  }
+
+  @override
+  String multiScanTotalPhotoCount(Object count) {
+    return 'Total photo count: $count';
+  }
+
+  @override
+  String get multiScanDetailsUnavailable => 'Photo analysis details are unavailable, but the merged result is safe to view.';
+
   @override
   String get tts_orderPhraseTitle => 'Создайте фразу для заказа';
 

--- a/lib/l10n/gen_l10n/app_localizations_te.dart
+++ b/lib/l10n/gen_l10n/app_localizations_te.dart
@@ -1002,6 +1002,43 @@ class AppLocalizationsTe extends AppLocalizations {
   @override
   String get result_aiEmptyStreamResponse => 'AI ద్వారా ఖాళీ స్ట్రీమ్ ప్రతిస్పందన వచ్చింది.';
 
+
+  @override
+  String get multiScanSummaryTitle => 'Multi-scan summary';
+
+  @override
+  String multiScanPhotoItemsDetected(Object index, Object count) {
+    return 'Photo $index: $count items detected';
+  }
+
+  @override
+  String multiScanPhotoItemsUnclear(Object index, Object count, Object unclear) {
+    return 'Photo $index: $count items detected / $unclear unclear';
+  }
+
+  @override
+  String multiScanNoReadableItems(Object index) {
+    return 'Photo $index: no readable menu items detected';
+  }
+
+  @override
+  String multiScanTotalSummary(Object total, Object unique) {
+    return 'Total $total detected / $unique after duplicate removal';
+  }
+
+  @override
+  String multiScanTotalSummaryWithDuplicates(Object total, Object unique, Object duplicates) {
+    return 'Total $total detected / $unique after duplicate removal ($duplicates duplicates)';
+  }
+
+  @override
+  String multiScanTotalPhotoCount(Object count) {
+    return 'Total photo count: $count';
+  }
+
+  @override
+  String get multiScanDetailsUnavailable => 'Photo analysis details are unavailable, but the merged result is safe to view.';
+
   @override
   String get tts_orderPhraseTitle => 'ఆర్డరింగ్ కోసం పదబంధం సృష్టించండి';
 

--- a/lib/l10n/gen_l10n/app_localizations_th.dart
+++ b/lib/l10n/gen_l10n/app_localizations_th.dart
@@ -1002,6 +1002,43 @@ class AppLocalizationsTh extends AppLocalizations {
   @override
   String get result_aiEmptyStreamResponse => 'ระบบ AI ส่งคืนการตอบกลับแบบสตรีมที่ว่างเปล่าแล้ว';
 
+
+  @override
+  String get multiScanSummaryTitle => 'Multi-scan summary';
+
+  @override
+  String multiScanPhotoItemsDetected(Object index, Object count) {
+    return 'Photo $index: $count items detected';
+  }
+
+  @override
+  String multiScanPhotoItemsUnclear(Object index, Object count, Object unclear) {
+    return 'Photo $index: $count items detected / $unclear unclear';
+  }
+
+  @override
+  String multiScanNoReadableItems(Object index) {
+    return 'Photo $index: no readable menu items detected';
+  }
+
+  @override
+  String multiScanTotalSummary(Object total, Object unique) {
+    return 'Total $total detected / $unique after duplicate removal';
+  }
+
+  @override
+  String multiScanTotalSummaryWithDuplicates(Object total, Object unique, Object duplicates) {
+    return 'Total $total detected / $unique after duplicate removal ($duplicates duplicates)';
+  }
+
+  @override
+  String multiScanTotalPhotoCount(Object count) {
+    return 'Total photo count: $count';
+  }
+
+  @override
+  String get multiScanDetailsUnavailable => 'Photo analysis details are unavailable, but the merged result is safe to view.';
+
   @override
   String get tts_orderPhraseTitle => 'สร้างประโยคสำหรับการสั่งซื้อ';
 

--- a/lib/l10n/gen_l10n/app_localizations_tr.dart
+++ b/lib/l10n/gen_l10n/app_localizations_tr.dart
@@ -1002,6 +1002,43 @@ class AppLocalizationsTr extends AppLocalizations {
   @override
   String get result_aiEmptyStreamResponse => 'Yapay zekâ boş bir akış yanıtı döndürdü.';
 
+
+  @override
+  String get multiScanSummaryTitle => 'Multi-scan summary';
+
+  @override
+  String multiScanPhotoItemsDetected(Object index, Object count) {
+    return 'Photo $index: $count items detected';
+  }
+
+  @override
+  String multiScanPhotoItemsUnclear(Object index, Object count, Object unclear) {
+    return 'Photo $index: $count items detected / $unclear unclear';
+  }
+
+  @override
+  String multiScanNoReadableItems(Object index) {
+    return 'Photo $index: no readable menu items detected';
+  }
+
+  @override
+  String multiScanTotalSummary(Object total, Object unique) {
+    return 'Total $total detected / $unique after duplicate removal';
+  }
+
+  @override
+  String multiScanTotalSummaryWithDuplicates(Object total, Object unique, Object duplicates) {
+    return 'Total $total detected / $unique after duplicate removal ($duplicates duplicates)';
+  }
+
+  @override
+  String multiScanTotalPhotoCount(Object count) {
+    return 'Total photo count: $count';
+  }
+
+  @override
+  String get multiScanDetailsUnavailable => 'Photo analysis details are unavailable, but the merged result is safe to view.';
+
   @override
   String get tts_orderPhraseTitle => 'Sipariş cümlesi oluşturun';
 

--- a/lib/l10n/gen_l10n/app_localizations_ur.dart
+++ b/lib/l10n/gen_l10n/app_localizations_ur.dart
@@ -1002,6 +1002,43 @@ class AppLocalizationsUr extends AppLocalizations {
   @override
   String get result_aiEmptyStreamResponse => 'AI نے خالی اسٹریم کا جواب واپس کیا۔';
 
+
+  @override
+  String get multiScanSummaryTitle => 'Multi-scan summary';
+
+  @override
+  String multiScanPhotoItemsDetected(Object index, Object count) {
+    return 'Photo $index: $count items detected';
+  }
+
+  @override
+  String multiScanPhotoItemsUnclear(Object index, Object count, Object unclear) {
+    return 'Photo $index: $count items detected / $unclear unclear';
+  }
+
+  @override
+  String multiScanNoReadableItems(Object index) {
+    return 'Photo $index: no readable menu items detected';
+  }
+
+  @override
+  String multiScanTotalSummary(Object total, Object unique) {
+    return 'Total $total detected / $unique after duplicate removal';
+  }
+
+  @override
+  String multiScanTotalSummaryWithDuplicates(Object total, Object unique, Object duplicates) {
+    return 'Total $total detected / $unique after duplicate removal ($duplicates duplicates)';
+  }
+
+  @override
+  String multiScanTotalPhotoCount(Object count) {
+    return 'Total photo count: $count';
+  }
+
+  @override
+  String get multiScanDetailsUnavailable => 'Photo analysis details are unavailable, but the merged result is safe to view.';
+
   @override
   String get tts_orderPhraseTitle => 'آرڈر کرنے کا جملہ بنائیں';
 

--- a/lib/l10n/gen_l10n/app_localizations_vi.dart
+++ b/lib/l10n/gen_l10n/app_localizations_vi.dart
@@ -1002,6 +1002,43 @@ class AppLocalizationsVi extends AppLocalizations {
   @override
   String get result_aiEmptyStreamResponse => 'AI đã trả về một phản hồi luồng trống.';
 
+
+  @override
+  String get multiScanSummaryTitle => 'Multi-scan summary';
+
+  @override
+  String multiScanPhotoItemsDetected(Object index, Object count) {
+    return 'Photo $index: $count items detected';
+  }
+
+  @override
+  String multiScanPhotoItemsUnclear(Object index, Object count, Object unclear) {
+    return 'Photo $index: $count items detected / $unclear unclear';
+  }
+
+  @override
+  String multiScanNoReadableItems(Object index) {
+    return 'Photo $index: no readable menu items detected';
+  }
+
+  @override
+  String multiScanTotalSummary(Object total, Object unique) {
+    return 'Total $total detected / $unique after duplicate removal';
+  }
+
+  @override
+  String multiScanTotalSummaryWithDuplicates(Object total, Object unique, Object duplicates) {
+    return 'Total $total detected / $unique after duplicate removal ($duplicates duplicates)';
+  }
+
+  @override
+  String multiScanTotalPhotoCount(Object count) {
+    return 'Total photo count: $count';
+  }
+
+  @override
+  String get multiScanDetailsUnavailable => 'Photo analysis details are unavailable, but the merged result is safe to view.';
+
   @override
   String get tts_orderPhraseTitle => 'Tạo cụm từ để đặt hàng';
 

--- a/lib/l10n/gen_l10n/app_localizations_zh.dart
+++ b/lib/l10n/gen_l10n/app_localizations_zh.dart
@@ -1002,6 +1002,43 @@ class AppLocalizationsZh extends AppLocalizations {
   @override
   String get result_aiEmptyStreamResponse => 'AI 返回了空的流响应。';
 
+
+  @override
+  String get multiScanSummaryTitle => 'Multi-scan summary';
+
+  @override
+  String multiScanPhotoItemsDetected(Object index, Object count) {
+    return 'Photo $index: $count items detected';
+  }
+
+  @override
+  String multiScanPhotoItemsUnclear(Object index, Object count, Object unclear) {
+    return 'Photo $index: $count items detected / $unclear unclear';
+  }
+
+  @override
+  String multiScanNoReadableItems(Object index) {
+    return 'Photo $index: no readable menu items detected';
+  }
+
+  @override
+  String multiScanTotalSummary(Object total, Object unique) {
+    return 'Total $total detected / $unique after duplicate removal';
+  }
+
+  @override
+  String multiScanTotalSummaryWithDuplicates(Object total, Object unique, Object duplicates) {
+    return 'Total $total detected / $unique after duplicate removal ($duplicates duplicates)';
+  }
+
+  @override
+  String multiScanTotalPhotoCount(Object count) {
+    return 'Total photo count: $count';
+  }
+
+  @override
+  String get multiScanDetailsUnavailable => 'Photo analysis details are unavailable, but the merged result is safe to view.';
+
   @override
   String get tts_orderPhraseTitle => '创建订购短语';
 
@@ -2091,6 +2128,43 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
   @override
   String get result_aiEmptyStreamResponse => 'AI 返回了一个空的流响应。';
 
+
+  @override
+  String get multiScanSummaryTitle => 'Multi-scan summary';
+
+  @override
+  String multiScanPhotoItemsDetected(Object index, Object count) {
+    return 'Photo $index: $count items detected';
+  }
+
+  @override
+  String multiScanPhotoItemsUnclear(Object index, Object count, Object unclear) {
+    return 'Photo $index: $count items detected / $unclear unclear';
+  }
+
+  @override
+  String multiScanNoReadableItems(Object index) {
+    return 'Photo $index: no readable menu items detected';
+  }
+
+  @override
+  String multiScanTotalSummary(Object total, Object unique) {
+    return 'Total $total detected / $unique after duplicate removal';
+  }
+
+  @override
+  String multiScanTotalSummaryWithDuplicates(Object total, Object unique, Object duplicates) {
+    return 'Total $total detected / $unique after duplicate removal ($duplicates duplicates)';
+  }
+
+  @override
+  String multiScanTotalPhotoCount(Object count) {
+    return 'Total photo count: $count';
+  }
+
+  @override
+  String get multiScanDetailsUnavailable => 'Photo analysis details are unavailable, but the merged result is safe to view.';
+
   @override
   String get tts_orderPhraseTitle => '创建订购短语';
 
@@ -3179,6 +3253,43 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String get result_aiEmptyStreamResponse => 'AI 返回了空的串流回應。';
+
+
+  @override
+  String get multiScanSummaryTitle => 'Multi-scan summary';
+
+  @override
+  String multiScanPhotoItemsDetected(Object index, Object count) {
+    return 'Photo $index: $count items detected';
+  }
+
+  @override
+  String multiScanPhotoItemsUnclear(Object index, Object count, Object unclear) {
+    return 'Photo $index: $count items detected / $unclear unclear';
+  }
+
+  @override
+  String multiScanNoReadableItems(Object index) {
+    return 'Photo $index: no readable menu items detected';
+  }
+
+  @override
+  String multiScanTotalSummary(Object total, Object unique) {
+    return 'Total $total detected / $unique after duplicate removal';
+  }
+
+  @override
+  String multiScanTotalSummaryWithDuplicates(Object total, Object unique, Object duplicates) {
+    return 'Total $total detected / $unique after duplicate removal ($duplicates duplicates)';
+  }
+
+  @override
+  String multiScanTotalPhotoCount(Object count) {
+    return 'Total photo count: $count';
+  }
+
+  @override
+  String get multiScanDetailsUnavailable => 'Photo analysis details are unavailable, but the merged result is safe to view.';
 
   @override
   String get tts_orderPhraseTitle => '創建下單用語';

--- a/lib/models/scan_mode.dart
+++ b/lib/models/scan_mode.dart
@@ -1,0 +1,15 @@
+enum ScanMode {
+  single,
+  multi,
+}
+
+extension ScanModeX on ScanMode {
+  String get wireName {
+    switch (this) {
+      case ScanMode.single:
+        return 'single';
+      case ScanMode.multi:
+        return 'multi';
+    }
+  }
+}

--- a/lib/screens/Loading_Screen.dart
+++ b/lib/screens/Loading_Screen.dart
@@ -96,45 +96,19 @@ class _LoadingScreenState extends State<LoadingScreen> {
     _showAdThenHandleGpt();
   }
 
-  /// geohash로 장소 메모를 DB에서 불러와 promptContext에 삽입한 뒤 GPT 호출
+  /// Legacy non-streaming analysis helper. Keep it aligned with _prepareVisionInput()
+  /// so multi-scan never analyzes only the first source image.
   Future<String> _prepareAndAnalyze() async {
-    String promptContext = '';
-    if (widget.position != null) {
-      final geohash = GeohashService().generateGeohash(
-        widget.position!.latitude,
-        widget.position!.longitude,
-      );
-      final firestoreFuture = FirebaseFirestore.instance
-          .collection('rag_data')
-          .where('geohashes', arrayContains: geohash)
-          .limit(1)
-          .get();
-
-      final prefsFuture = SharedPreferences.getInstance();
-
-      final results = await Future.wait([firestoreFuture, prefsFuture]);
-
-      final snapshot = results[0] as QuerySnapshot;
-      final prefs = results[1] as SharedPreferences;
-
-      if (snapshot.docs.isNotEmpty) {
-        final data = snapshot.docs.first.data() as Map<String, dynamic>;
-        String lang = prefs.getString('selectedLanguageCode') ?? Platform.localeName.split('_').first;
-        lang = lang.replaceAll('-', '_');
-        promptContext = data['detail_$lang'] ?? '';
-      }
-
-    }
-    print('▶️ [RAG Context] promptContext: $promptContext');
-    final files = widget.images ?? [widget.image!];
-    final scanMode = files.length > 1 ? ScanMode.multi : ScanMode.single;
+    final prepared = await _prepareVisionInput();
     return VisionService.analyzeImage(
-      files.first,
-      promptContext: promptContext,
-      scanMode: scanMode,
-      photoCount: files.length,
+      prepared.visionFile,
+      promptContext: prepared.promptContext,
+      scanMode: prepared.scanMode,
+      photoCount: prepared.photoCount,
+      maxOutputTokens: widget.maxOutputTokens,
     );
   }
+
 
 
   @override

--- a/lib/screens/Loading_Screen.dart
+++ b/lib/screens/Loading_Screen.dart
@@ -18,6 +18,7 @@ import 'dart:typed_data';
 import 'package:flutter/foundation.dart';
 import 'package:path_provider/path_provider.dart';
 import '/screens/image_merge_service.dart';
+import 'package:mscanner/models/scan_mode.dart';
 import 'package:mscanner/utils/async_request_gate.dart';
 
 
@@ -29,7 +30,14 @@ Future<Uint8List> mergeImages(List<Uint8List> bytesList) async {
 class _PreparedVisionInput {
   final File visionFile;
   final String promptContext;
-  _PreparedVisionInput(this.visionFile, this.promptContext);
+  final ScanMode scanMode;
+  final int photoCount;
+  _PreparedVisionInput(
+    this.visionFile,
+    this.promptContext,
+    this.scanMode,
+    this.photoCount,
+  );
 }
 
 
@@ -119,9 +127,12 @@ class _LoadingScreenState extends State<LoadingScreen> {
     }
     print('▶️ [RAG Context] promptContext: $promptContext');
     final files = widget.images ?? [widget.image!];
+    final scanMode = files.length > 1 ? ScanMode.multi : ScanMode.single;
     return VisionService.analyzeImage(
       files.first,
       promptContext: promptContext,
+      scanMode: scanMode,
+      photoCount: files.length,
     );
   }
 
@@ -229,7 +240,8 @@ class _LoadingScreenState extends State<LoadingScreen> {
       print('🗜️ [Vision] send file size = ${(sz / 1024).toStringAsFixed(1)} KB');
     } catch (_) {}
 
-    return _PreparedVisionInput(visionFile, promptContext);
+    final scanMode = files.length > 1 ? ScanMode.multi : ScanMode.single;
+    return _PreparedVisionInput(visionFile, promptContext, scanMode, files.length);
   }
 
   Future<List<String>> _waitFirstRecommendFromStream(
@@ -289,6 +301,8 @@ class _LoadingScreenState extends State<LoadingScreen> {
           prepared.visionFile,
           promptContext: prepared.promptContext,
           maxOutputTokens: widget.maxOutputTokens,
+          scanMode: prepared.scanMode,
+          photoCount: prepared.photoCount,
         );
 
         final stream = rawStream
@@ -327,6 +341,8 @@ class _LoadingScreenState extends State<LoadingScreen> {
             prepared.visionFile,
             promptContext: prepared.promptContext,
             maxOutputTokens: widget.maxOutputTokens,
+            scanMode: prepared.scanMode,
+            photoCount: prepared.photoCount,
           ).timeout(_fallbackAnalyzeTimeout);
 
           if (!_hasNavigated && mounted) {
@@ -358,10 +374,9 @@ class _LoadingScreenState extends State<LoadingScreen> {
     if (!mounted || _hasNavigated) return;
     setState(() => _isLoadingError = true);
     Future.delayed(Duration(seconds: 5), () {
-      if (!_hasNavigated) {
-        _hasNavigated = true;
-        Navigator.of(context).pushReplacementNamed('/home');
-      }
+      if (!mounted || _hasNavigated) return;
+      _hasNavigated = true;
+      Navigator.of(context).pushReplacementNamed('/home');
     });
   }
 

--- a/lib/screens/Result_Screen.dart
+++ b/lib/screens/Result_Screen.dart
@@ -375,10 +375,11 @@ class _ResultScreenState extends State<ResultScreen> {
         ? _asInt(merged['totalPhotoCount'])
         : (widget.images?.length ?? 1);
     final muted = textColor.withOpacity(0.72);
+    final loc = AppLocalizations.of(context)!;
 
     final lines = <String>[];
     if (analyses.isEmpty) {
-      lines.add('Photo analysis details are unavailable, but the merged result is safe to view.');
+      lines.add(loc.multiScanDetailsUnavailable);
     } else {
       for (final analysis in analyses) {
         final index = _asInt(analysis['photoIndex']);
@@ -386,19 +387,20 @@ class _ResultScreenState extends State<ResultScreen> {
         final itemCount = _asInt(analysis['itemCount']);
         final unclearCount = _asInt(analysis['unclearItemCount']);
         if (itemCount <= 0 && unclearCount <= 0) {
-          lines.add('Photo $displayIndex: no readable menu items detected');
+          lines.add(loc.multiScanNoReadableItems(displayIndex));
         } else if (unclearCount > 0) {
-          lines.add('Photo $displayIndex: $itemCount items detected / $unclearCount unclear');
+          lines.add(loc.multiScanPhotoItemsUnclear(displayIndex, itemCount, unclearCount));
         } else {
-          lines.add('Photo $displayIndex: $itemCount items detected');
+          lines.add(loc.multiScanPhotoItemsDetected(displayIndex, itemCount));
         }
       }
     }
 
     final totalLine = total > 0 || unique > 0 || duplicate > 0
-        ? 'Total $total detected / $unique after duplicate removal'
-            '${duplicate > 0 ? ' ($duplicate duplicates)' : ''}'
-        : 'Total photo count: $photoCount';
+        ? (duplicate > 0
+            ? loc.multiScanTotalSummaryWithDuplicates(total, unique, duplicate)
+            : loc.multiScanTotalSummary(total, unique))
+        : loc.multiScanTotalPhotoCount(photoCount);
 
     return Container(
       decoration: boxDecoration,
@@ -411,7 +413,7 @@ class _ResultScreenState extends State<ResultScreen> {
               Icon(CupertinoIcons.square_stack_3d_up, size: 18, color: textColor),
               const SizedBox(width: 8),
               Text(
-                'Multi-scan summary',
+                loc.multiScanSummaryTitle,
                 style: TextStyle(
                   fontFamily: 'SFPro',
                   fontSize: 15,

--- a/lib/screens/Result_Screen.dart
+++ b/lib/screens/Result_Screen.dart
@@ -337,6 +337,138 @@ class _ResultScreenState extends State<ResultScreen> {
     return ResultParsingService.getRecommendedItems(_aiJson);
   }
 
+  bool get _isMultiScanResult {
+    final jsonMode = (_aiJson?['scanMode'] ?? '').toString().toLowerCase();
+    return jsonMode == 'multi' || ((widget.images?.length ?? 1) > 1);
+  }
+
+  List<Map<String, dynamic>> _getPhotoAnalyses() {
+    return ResultParsingService.getPhotoAnalyses(_aiJson);
+  }
+
+  Map<String, dynamic> _getMergedResult() {
+    return ResultParsingService.getMergedResult(
+      _aiJson,
+      fallbackPhotoCount: widget.images?.length ?? 1,
+    );
+  }
+
+  int _asInt(dynamic value) {
+    if (value is int) return value;
+    if (value is num) return value.round();
+    if (value is String) return int.tryParse(value.trim()) ?? 0;
+    return 0;
+  }
+
+  Widget _buildMultiScanSummaryCard({
+    required Color textColor,
+    required BoxDecoration boxDecoration,
+  }) {
+    if (!_isMultiScanResult) return const SizedBox.shrink();
+
+    final analyses = _getPhotoAnalyses();
+    final merged = _getMergedResult();
+    final total = _asInt(merged['totalItemCount']);
+    final unique = _asInt(merged['uniqueItemCount']);
+    final duplicate = _asInt(merged['duplicateItemCount']);
+    final photoCount = _asInt(merged['totalPhotoCount']) > 0
+        ? _asInt(merged['totalPhotoCount'])
+        : (widget.images?.length ?? 1);
+    final muted = textColor.withOpacity(0.72);
+
+    final lines = <String>[];
+    if (analyses.isEmpty) {
+      lines.add('Photo analysis details are unavailable, but the merged result is safe to view.');
+    } else {
+      for (final analysis in analyses) {
+        final index = _asInt(analysis['photoIndex']);
+        final displayIndex = index > 0 ? index : lines.length + 1;
+        final itemCount = _asInt(analysis['itemCount']);
+        final unclearCount = _asInt(analysis['unclearItemCount']);
+        if (itemCount <= 0 && unclearCount <= 0) {
+          lines.add('Photo $displayIndex: no readable menu items detected');
+        } else if (unclearCount > 0) {
+          lines.add('Photo $displayIndex: $itemCount items detected / $unclearCount unclear');
+        } else {
+          lines.add('Photo $displayIndex: $itemCount items detected');
+        }
+      }
+    }
+
+    final totalLine = total > 0 || unique > 0 || duplicate > 0
+        ? 'Total $total detected / $unique after duplicate removal'
+            '${duplicate > 0 ? ' ($duplicate duplicates)' : ''}'
+        : 'Total photo count: $photoCount';
+
+    return Container(
+      decoration: boxDecoration,
+      padding: const EdgeInsets.all(12),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Icon(CupertinoIcons.square_stack_3d_up, size: 18, color: textColor),
+              const SizedBox(width: 8),
+              Text(
+                'Multi-scan summary',
+                style: TextStyle(
+                  fontFamily: 'SFPro',
+                  fontSize: 15,
+                  fontWeight: FontWeight.w700,
+                  color: textColor,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          ...lines.map(
+            (line) => Padding(
+              padding: const EdgeInsets.only(top: 3),
+              child: Text(
+                line,
+                style: TextStyle(
+                  fontFamily: 'SFPro',
+                  fontSize: 12,
+                  height: 1.35,
+                  color: muted,
+                ),
+              ),
+            ),
+          ),
+          const SizedBox(height: 6),
+          Text(
+            totalLine,
+            style: TextStyle(
+              fontFamily: 'SFPro',
+              fontSize: 12,
+              fontWeight: FontWeight.w700,
+              color: textColor,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Map<String, dynamic> _multiScanSaveFields() {
+    if (!_isMultiScanResult) {
+      return {'scanMode': 'single', 'photoCount': widget.images?.length ?? 1};
+    }
+    final photoAnalyses = _getPhotoAnalyses();
+    final merged = _getMergedResult();
+    return {
+      'scanMode': 'multi',
+      'photoCount': widget.images?.length ?? _asInt(merged['totalPhotoCount']),
+      'photoAnalyses': photoAnalyses,
+      'mergedResult': merged,
+      'totalItemCount': _asInt(merged['totalItemCount']),
+      'uniqueItemCount': _asInt(merged['uniqueItemCount']),
+      'duplicateItemCount': _asInt(merged['duplicateItemCount']),
+    };
+  }
+
+
   String _aiResultType() {
     return ResultParsingService.aiResultType(_aiJson);
   }
@@ -424,10 +556,13 @@ class _ResultScreenState extends State<ResultScreen> {
     if (s == null) return false;
 
     try {
-      final decoded = jsonDecode(s);
-      if (decoded is Map) {
-        _aiJson = Map<String, dynamic>.from(decoded);
-        _aiJsonError = null;
+      final parsed = ResultParsingService.parseAiJson(
+        responses: [s],
+        imageCount: widget.images?.length ?? 1,
+      );
+      if (parsed.aiJson != null) {
+        _aiJson = parsed.aiJson;
+        _aiJsonError = parsed.aiJsonError;
         return true;
       }
     } catch (e) {
@@ -3169,6 +3304,7 @@ class _ResultScreenState extends State<ResultScreen> {
           'food_detail': _foodDetail,
           'liked': _isLiked,
           if (primary != null) 'primary_menu': primary,
+          ..._multiScanSaveFields(),
           // ✅ 나중에 준비되면 이 필드도 같이 저장하면 “대표 음식사진” 표시 가능
           // 'food_image_url': foodImageUrl,
           'review': _reviewController.text.trim(),
@@ -4031,6 +4167,13 @@ class _ResultScreenState extends State<ResultScreen> {
                     ),
                     SizedBox(height: 16),
                     _buildDecisionSummarySection(),
+                    if (_isMultiScanResult) ...[
+                      SizedBox(height: 16),
+                      _buildMultiScanSummaryCard(
+                        textColor: textColor,
+                        boxDecoration: boxDecoration,
+                      ),
+                    ],
                     SizedBox(height: 16),
 
                     // ✅ NEW UI (JSON-based) with fallback to old text

--- a/lib/screens/image_merge_service.dart
+++ b/lib/screens/image_merge_service.dart
@@ -16,6 +16,7 @@ class ImageMergeService {
     final cellH = images.map((i) => i.height).reduce(max);
 
     // 3) 비율 유지 중앙 크롭
+    final labelH = count > 1 ? 56 : 0;
     final fitted = images.map((src) => _fitAndCrop(src, cellW, cellH)).toList();
 
     // 4) 그리드(column, row) 계산
@@ -23,13 +24,31 @@ class ImageMergeService {
     final rows = (count == 2) ? 2 : ((count + 1) ~/ 2);
 
     // 5) 빈 캔버스 생성 (named parameters)
-    final merged = Image(width: cellW * cols, height: cellH * rows);
+    final merged = Image(width: cellW * cols, height: (cellH + labelH) * rows);
 
     // 6) 각 셀에 compositeImage 로 붙여넣기
     for (int i = 0; i < count; i++) {
       final x = (i % cols) * cellW;
-      final y = (i ~/ cols) * cellH;
-      compositeImage(merged, fitted[i], dstX: x, dstY: y);
+      final y = (i ~/ cols) * (cellH + labelH);
+      if (labelH > 0) {
+        fillRect(
+          merged,
+          x1: x,
+          y1: y,
+          x2: x + cellW - 1,
+          y2: y + labelH - 1,
+          color: ColorRgb8(255, 255, 255),
+        );
+        drawString(
+          merged,
+          '[PHOTO ${i + 1}]',
+          font: arial24,
+          x: x + 16,
+          y: y + 16,
+          color: ColorRgb8(0, 0, 0),
+        );
+      }
+      compositeImage(merged, fitted[i], dstX: x, dstY: y + labelH);
     }
 
     // 7) JPEG 압축 후 반환

--- a/lib/screens/result/result_parsing_service.dart
+++ b/lib/screens/result/result_parsing_service.dart
@@ -249,10 +249,13 @@ class ResultParsingService {
       fallbackUniqueCount: _countLegacyMenuItems(normalized),
     );
 
+    final hadLegacyMenuItems = _countLegacyMenuItems(normalized) > 0;
+
     normalized['scanMode'] = 'multi';
     normalized['photoAnalyses'] = photoAnalyses;
     normalized['mergedResult'] = mergedResult;
-    if (_countLegacyMenuItems(normalized) == 0 && photoAnalyses.isNotEmpty) {
+    _applyRecommendedItemsFallback(normalized, mergedResult);
+    if (!hadLegacyMenuItems && photoAnalyses.isNotEmpty) {
       normalized['fullMenu'] = {
         'items': {
           'main': <Map<String, dynamic>>[],
@@ -304,10 +307,24 @@ class ResultParsingService {
       m['detectedSections'] = (m['detectedSections'] is List)
           ? List<dynamic>.from(m['detectedSections'] as List)
           : <dynamic>[];
-      m['itemCount'] = _intValue(m['itemCount']);
-      m['readableItemCount'] = _intValue(m['readableItemCount']);
-      m['unclearItemCount'] = _intValue(m['unclearItemCount']);
-      m['items'] = (m['items'] is List) ? List<dynamic>.from(m['items'] as List) : <dynamic>[];
+      final items = (m['items'] is List)
+          ? List<dynamic>.from(m['items'] as List)
+          : <dynamic>[];
+      final rawItemCount = _intValue(m['itemCount']);
+      final rawUnclearCount = _intValue(m['unclearItemCount']);
+      final fallbackItemCount = items.whereType<Map>().length;
+      final itemCount = rawItemCount > 0 ? rawItemCount : fallbackItemCount;
+      final unclearCount = rawUnclearCount;
+      final rawReadableCount = _intValue(m['readableItemCount']);
+      final fallbackReadableCount = itemCount - unclearCount;
+      final readableCount = rawReadableCount > 0
+          ? rawReadableCount
+          : fallbackReadableCount.clamp(0, itemCount).toInt();
+
+      m['items'] = items;
+      m['itemCount'] = itemCount;
+      m['unclearItemCount'] = unclearCount;
+      m['readableItemCount'] = readableCount;
       return m;
     }).toList();
   }
@@ -346,6 +363,40 @@ class ResultParsingService {
   }
 
 
+
+  static void _applyRecommendedItemsFallback(
+    Map<String, dynamic> normalized,
+    Map<String, dynamic> mergedResult,
+  ) {
+    final existing = normalized['recommended'];
+    if (existing is List && existing.isNotEmpty) return;
+
+    final rawRecommendedItems = mergedResult['recommendedItems'];
+    if (rawRecommendedItems is! List || rawRecommendedItems.isEmpty) return;
+
+    var id = 1;
+    final mapped = <Map<String, dynamic>>[];
+    for (final item in rawRecommendedItems.whereType<Map>()) {
+      final m = Map<String, dynamic>.from(item);
+      final original = (m['originalName'] ?? m['nameOriginal'] ?? '').toString();
+      final name = (m['translatedName'] ?? m['name'] ?? original).toString();
+      if (original.trim().isEmpty && name.trim().isEmpty) continue;
+
+      mapped.add({
+        'id': (m['id'] ?? 'mr${id++}').toString(),
+        'nameOriginal': original,
+        'name': name.trim().isNotEmpty ? name : original,
+        'shortDesc': (m['description'] ?? m['shortDesc'] ?? '').toString(),
+        'price': (m['price'] ?? '').toString(),
+        'reason': (m['reason'] ?? '').toString(),
+        'tags': m['tags'] is List ? List<dynamic>.from(m['tags'] as List) : <dynamic>[],
+      });
+    }
+
+    if (mapped.isNotEmpty) {
+      normalized['recommended'] = mapped;
+    }
+  }
   static List<Map<String, dynamic>> _itemsFromPhotoAnalyses(
     List<Map<String, dynamic>> photoAnalyses,
   ) {

--- a/lib/screens/result/result_parsing_service.dart
+++ b/lib/screens/result/result_parsing_service.dart
@@ -100,6 +100,13 @@ class ResultParsingService {
           (normalized['result_type'] ?? 'menu').toString().trim().toLowerCase();
       normalized['user_message'] =
           (normalized['user_message'] ?? '').toString().trim();
+      if ((normalized['scanMode'] ?? '').toString().toLowerCase() == 'multi') {
+        return ResultParsingOutput(
+          aiJson: normalizeMultiScanFields(normalized, imageCount: imageCount),
+          aiJsonError: null,
+        );
+      }
+      normalized['scanMode'] = (normalized['scanMode'] ?? 'single').toString();
       return ResultParsingOutput(aiJson: normalized, aiJsonError: null);
     }
 
@@ -153,7 +160,10 @@ class ResultParsingService {
         (merged['result_type'] ?? 'menu').toString().trim().toLowerCase();
     merged['user_message'] = (merged['user_message'] ?? '').toString().trim();
 
-    return ResultParsingOutput(aiJson: merged, aiJsonError: null);
+    return ResultParsingOutput(
+      aiJson: normalizeMultiScanFields(merged, imageCount: imageCount),
+      aiJsonError: null,
+    );
   }
 
   static List<Map<String, dynamic>> getRecommendedItems(Map<String, dynamic>? aiJson) {
@@ -226,4 +236,166 @@ class ResultParsingService {
     }
     return out;
   }
+  static Map<String, dynamic> normalizeMultiScanFields(
+    Map<String, dynamic> input, {
+    required int imageCount,
+  }) {
+    final normalized = Map<String, dynamic>.from(input);
+    final photoAnalyses = _safePhotoAnalyses(normalized['photoAnalyses']);
+    final mergedResult = _safeMergedResult(
+      normalized['mergedResult'],
+      photoAnalyses: photoAnalyses,
+      fallbackPhotoCount: imageCount,
+      fallbackUniqueCount: _countLegacyMenuItems(normalized),
+    );
+
+    normalized['scanMode'] = 'multi';
+    normalized['photoAnalyses'] = photoAnalyses;
+    normalized['mergedResult'] = mergedResult;
+    if (_countLegacyMenuItems(normalized) == 0 && photoAnalyses.isNotEmpty) {
+      normalized['fullMenu'] = {
+        'items': {
+          'main': <Map<String, dynamic>>[],
+          'side': <Map<String, dynamic>>[],
+          'meal': <Map<String, dynamic>>[],
+          'drink': <Map<String, dynamic>>[],
+          'beverage': <Map<String, dynamic>>[],
+          'unknown': _itemsFromPhotoAnalyses(photoAnalyses),
+        },
+        'summary': '',
+        'truncated': false,
+      };
+    }
+
+    return normalized;
+  }
+
+  static List<Map<String, dynamic>> getPhotoAnalyses(Map<String, dynamic>? aiJson) {
+    if (aiJson == null) return const [];
+    return _safePhotoAnalyses(aiJson['photoAnalyses']);
+  }
+
+  static Map<String, dynamic> getMergedResult(
+    Map<String, dynamic>? aiJson, {
+    required int fallbackPhotoCount,
+  }) {
+    if (aiJson == null) {
+      return _safeMergedResult(
+        null,
+        photoAnalyses: const [],
+        fallbackPhotoCount: fallbackPhotoCount,
+        fallbackUniqueCount: 0,
+      );
+    }
+    final photoAnalyses = _safePhotoAnalyses(aiJson['photoAnalyses']);
+    return _safeMergedResult(
+      aiJson['mergedResult'],
+      photoAnalyses: photoAnalyses,
+      fallbackPhotoCount: fallbackPhotoCount,
+      fallbackUniqueCount: _countLegacyMenuItems(aiJson),
+    );
+  }
+
+  static List<Map<String, dynamic>> _safePhotoAnalyses(dynamic raw) {
+    if (raw is! List) return <Map<String, dynamic>>[];
+    return raw.whereType<Map>().map((e) {
+      final m = Map<String, dynamic>.from(e);
+      m['photoIndex'] = _intValue(m['photoIndex']);
+      m['detectedSections'] = (m['detectedSections'] is List)
+          ? List<dynamic>.from(m['detectedSections'] as List)
+          : <dynamic>[];
+      m['itemCount'] = _intValue(m['itemCount']);
+      m['readableItemCount'] = _intValue(m['readableItemCount']);
+      m['unclearItemCount'] = _intValue(m['unclearItemCount']);
+      m['items'] = (m['items'] is List) ? List<dynamic>.from(m['items'] as List) : <dynamic>[];
+      return m;
+    }).toList();
+  }
+
+  static Map<String, dynamic> _safeMergedResult(
+    dynamic raw, {
+    required List<Map<String, dynamic>> photoAnalyses,
+    required int fallbackPhotoCount,
+    required int fallbackUniqueCount,
+  }) {
+    final m = raw is Map ? Map<String, dynamic>.from(raw) : <String, dynamic>{};
+    final totalFromPhotos = photoAnalyses.fold<int>(0, (sum, e) => sum + _intValue(e['itemCount']));
+    final unique = _intValue(m['uniqueItemCount']) > 0
+        ? _intValue(m['uniqueItemCount'])
+        : (fallbackUniqueCount > 0 ? fallbackUniqueCount : totalFromPhotos);
+    final total = _intValue(m['totalItemCount']) > 0
+        ? _intValue(m['totalItemCount'])
+        : (totalFromPhotos > 0 ? totalFromPhotos : fallbackUniqueCount);
+    final duplicates = _intValue(m['duplicateItemCount']) > 0
+        ? _intValue(m['duplicateItemCount'])
+        : (total > unique ? total - unique : 0);
+
+    return {
+      ...m,
+      'totalPhotoCount': _intValue(m['totalPhotoCount']) > 0
+          ? _intValue(m['totalPhotoCount'])
+          : fallbackPhotoCount,
+      'totalItemCount': total,
+      'uniqueItemCount': unique,
+      'duplicateItemCount': duplicates,
+      'recommendedItems': m['recommendedItems'] is List ? m['recommendedItems'] : <dynamic>[],
+      'signatureItems': m['signatureItems'] is List ? m['signatureItems'] : <dynamic>[],
+      'popularItems': m['popularItems'] is List ? m['popularItems'] : <dynamic>[],
+      'localInsights': m['localInsights'] is List ? m['localInsights'] : <dynamic>[],
+    };
+  }
+
+
+  static List<Map<String, dynamic>> _itemsFromPhotoAnalyses(
+    List<Map<String, dynamic>> photoAnalyses,
+  ) {
+    final out = <Map<String, dynamic>>[];
+    var id = 1;
+    for (final analysis in photoAnalyses) {
+      final items = analysis['items'];
+      if (items is! List) continue;
+      for (final item in items.whereType<Map>()) {
+        final m = Map<String, dynamic>.from(item);
+        final original = (m['originalName'] ?? m['nameOriginal'] ?? '').toString();
+        final translated = (m['translatedName'] ?? m['name'] ?? original).toString();
+        if (original.trim().isEmpty && translated.trim().isEmpty) continue;
+        out.add({
+          'id': 'p${analysis['photoIndex']}_${id++}',
+          'nameOriginal': original,
+          'name': translated.trim().isNotEmpty ? translated : original,
+          'shortDesc': (m['description'] ?? m['shortDesc'] ?? '').toString(),
+          'price': (m['price'] ?? '').toString(),
+          'tags': <String>[],
+          'category': 'unknown',
+          'confidence': m['confidence'] ?? 0.0,
+          'isUnclear': m['isUnclear'] == true,
+        });
+      }
+    }
+    return _dedupList(out);
+  }
+  static int _intValue(dynamic value) {
+    if (value is int) return value;
+    if (value is num) return value.round();
+    if (value is String) return int.tryParse(value.trim()) ?? 0;
+    return 0;
+  }
+
+  static int _countLegacyMenuItems(Map<String, dynamic> aiJson) {
+    var count = 0;
+    final rec = aiJson['recommended'];
+    if (rec is List) count += rec.whereType<Map>().length;
+
+    final fm = aiJson['fullMenu'] ?? aiJson['full_menu'] ?? aiJson['menu'] ?? aiJson['menus'];
+    if (fm is Map) {
+      final src = (fm['items'] is Map)
+          ? Map<String, dynamic>.from(fm['items'] as Map)
+          : Map<String, dynamic>.from(fm);
+      for (final v in src.values) {
+        if (v is List) count += v.whereType<Map>().length;
+      }
+    }
+    return count;
+  }
+
 }

--- a/lib/screens/vision_prompt_builder.dart
+++ b/lib/screens/vision_prompt_builder.dart
@@ -1,0 +1,150 @@
+import 'package:mscanner/models/scan_mode.dart';
+
+String buildVisionPrompt({
+  required ScanMode scanMode,
+  required String targetLanguage,
+  required String promptContext,
+  required String question,
+  int photoCount = 1,
+}) {
+  switch (scanMode) {
+    case ScanMode.single:
+      return buildSingleScanPrompt(
+        targetLanguage: targetLanguage,
+        promptContext: promptContext,
+        question: question,
+      );
+    case ScanMode.multi:
+      return buildMultiScanPrompt(
+        targetLanguage: targetLanguage,
+        promptContext: promptContext,
+        question: question,
+        photoCount: photoCount,
+      );
+  }
+}
+
+String _baseOutputProtocol({required String keyOrder}) => '''[OUTPUT PROTOCOL]
+Output exactly ONE JSON object.
+- No RECOMMEND line
+- No markdown
+- No code fences
+- No extra text
+- Return valid JSON only.
+- Keep the JSON key order as: $keyOrder
+''';
+
+String _localizedIntro({
+  required String targetLanguage,
+  required String promptContext,
+  required String question,
+}) => '''[Location Memo]
+$promptContext
+
+If this image is a food menu or food photo, translate it into targetLanguage="$targetLanguage", describe useful details, and recommend dishes.
+If it does not seem food-related, return isMenu=false in valid JSON.
+
+[Existing user preset / app schema instructions]
+$question
+''';
+
+String _sharedMenuRequirements(String targetLanguage) => '''
+[Shared menu extraction requirements]
+- Preserve the existing app JSON fields whenever possible: isMenu, userMessage, outputLanguage, place, recommended, fullMenu.
+- outputLanguage must be "$targetLanguage".
+- Extract only visible menu items. Do not invent unseen dishes.
+- Include original menu names, translated names, prices, concise descriptions, recommendation reasons, signature/popular hints, spicy level, allergy/caution information, and local insights when supported by visible text or provided context.
+- Mark low-confidence or partially unreadable text clearly instead of guessing.
+- Return valid JSON only.
+''';
+
+String buildSingleScanPrompt({
+  required String targetLanguage,
+  required String promptContext,
+  required String question,
+}) {
+  return '''${_baseOutputProtocol(keyOrder: 'isMenu, scanMode, outputLanguage, place, recommended, fullMenu')}
+${_localizedIntro(targetLanguage: targetLanguage, promptContext: promptContext, question: question)}
+${_sharedMenuRequirements(targetLanguage)}
+[Single scan mode]
+- scanMode must be "single".
+- Analyze this as one menu photo.
+- Keep the existing single-scan result format compatible with the current UI.
+- The result should focus on menu item extraction, translation, prices, descriptions, recommended dishes, signature/popular items, spicy level, allergy/caution notes, and local insights when available.
+- Do not add multi-scan-only fields unless they are empty/omitted.
+''';
+}
+
+String buildMultiScanPrompt({
+  required String targetLanguage,
+  required String promptContext,
+  required String question,
+  required int photoCount,
+}) {
+  return '''${_baseOutputProtocol(keyOrder: 'isMenu, scanMode, outputLanguage, place, recommended, fullMenu, photoAnalyses, mergedResult')}
+${_localizedIntro(targetLanguage: targetLanguage, promptContext: promptContext, question: question)}
+${_sharedMenuRequirements(targetLanguage)}
+[Multi scan mode]
+You are analyzing multiple food menu photos.
+Treat each photo as a separate source.
+Analyze each photo independently first.
+For each photo, return photoIndex, detectedSections, itemCount, readableItemCount, unclearItemCount, and items.
+After all photos are analyzed, merge the results.
+Remove duplicates only in the mergedResult.
+Do not mix prices, descriptions, or sections between different photos.
+If an item is unclear, mark it as unclear instead of guessing.
+Return valid JSON only.
+
+Required analysis order:
+1. Treat each photo as a separate source. If the image is a labeled collage, use labels like [PHOTO 1], [PHOTO 2], etc. to assign photoIndex.
+2. Extract menu items for each photo independently.
+3. Count itemCount for each photo.
+4. Count readableItemCount and unclearItemCount for each photo.
+5. Summarize detectedSections for each photo.
+6. Only after all photoAnalyses are complete, merge the whole result.
+7. Remove duplicates only in mergedResult.
+8. Do not mix prices, descriptions, or sections between different photos.
+9. If an item is unclear, mark it as unclear instead of guessing.
+10. Build final recommended/signature/popular/local insights from mergedResult only.
+
+Multi-scan JSON requirements:
+- scanMode must be "multi".
+- totalPhotoCount should be $photoCount.
+- Keep existing fields recommended and fullMenu populated from the merged result so legacy UI still works.
+- Add the following fields as additive fields:
+{
+  "scanMode": "multi",
+  "photoAnalyses": [
+    {
+      "photoIndex": 1,
+      "detectedSections": [],
+      "itemCount": 0,
+      "readableItemCount": 0,
+      "unclearItemCount": 0,
+      "items": [
+        {
+          "originalName": "",
+          "translatedName": "",
+          "description": "",
+          "price": "",
+          "spicyLevel": "",
+          "confidence": 0.0,
+          "isUnclear": false
+        }
+      ]
+    }
+  ],
+  "mergedResult": {
+    "totalPhotoCount": $photoCount,
+    "totalItemCount": 0,
+    "uniqueItemCount": 0,
+    "duplicateItemCount": 0,
+    "recommendedItems": [],
+    "signatureItems": [],
+    "popularItems": [],
+    "localInsights": []
+  }
+}
+- If one photo fails or has no readable items, still include a photoAnalyses entry with itemCount=0, readableItemCount=0, unclearItemCount=0 or the number of unclear items, items=[], and a short failure/caution string if needed.
+''';
+}

--- a/lib/screens/vision_service.dart
+++ b/lib/screens/vision_service.dart
@@ -3,6 +3,8 @@ import 'dart:io';
 import 'package:http/http.dart' as http;
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import '/helpers/settings_helper.dart';
+import 'package:mscanner/models/scan_mode.dart';
+import 'package:mscanner/screens/vision_prompt_builder.dart';
 import 'package:mscanner/utils/sse_event_parser.dart';
 
 class VisionService {
@@ -19,6 +21,8 @@ class VisionService {
       File imageFile, {
         String? promptContext,
         int maxOutputTokens = 3000, // ✅ 추가
+        ScanMode scanMode = ScanMode.single,
+        int photoCount = 1,
       }) async {
 
     try {
@@ -32,209 +36,19 @@ class VisionService {
 
 
       final presetId = await SettingsHelper.getPreset();
-      const String _streamProtocol = '''[OUTPUT PROTOCOL]
-Output exactly ONE JSON object.
-- No RECOMMEND line
-- No markdown
-- No code fences
-- No extra text
-- Keep the JSON key order as: isMenu, outputLanguage, place, recommended, fullMenu
-''';
       final question = await SettingsHelper.getQuestionByPreset(presetId);
 
-      // 1) RAG + 프리셋 질문을 하나로 합친 텍스트
-      final Map<String, String> ragPrefixMap = {
-        'ko': '''[장소 메모]
-{promptContext}
-
-이 이미지가 음식 메뉴나 음식 사진이라면, 내용을 번역하고 설명 및 추천해 주세요.
-음식과 관련 없어 보이면 그렇게 말씀해 주세요.
-
-{question}
-''',
-        'en': '''[Location Memo]
-{promptContext}
-
-If this image is a food menu or food photo, please translate, describe, and recommend it.
-If it doesn’t seem food-related, just say so.
-
-{question}
-''',
-        'ja': '''[Location Memo]
-{promptContext}
-
-この画像が料理のメニューや料理の写真であれば、翻訳して説明し、推薦してください。
-食べ物に関係がないようであれば、そのように言ってください。
-
-{question}
-''',
-        'zh': '''[Location Memo]
-{promptContext}
-
-如果此图像是食物菜单或食物照片，请翻译、描述并推荐。
-如果看起来与食物无关，请指出。
-
-{question}
-''',
-        'zh-Hans': '''[Location Memo]
-{promptContext}
-
-如果此图像是食物菜单或食物照片，请翻译、描述并推荐。
-如果看起来与食物无关，请指出。
-
-{question}
-''',
-        'zh-Hant': '''[Location Memo]
-{promptContext}
-
-如果此圖像是食物菜單或食物照片，請翻譯、描述並推薦。
-如果看起來與食物無關，請說明。
-
-{question}
-''',
-        'hi': '''[Location Memo]
-{promptContext}
-
-यदि यह चित्र खाद्य मेनू या खाद्य फ़ोटो है, तो कृपया इसका अनुवाद करें, वर्णन करें और अनुशंसा करें।
-यदि यह खाद्य से संबंधित नहीं लगता है, तो बस बता दें।
-
-{question}
-''',
-        'es': '''[Location Memo]
-{promptContext}
-
-Si esta imagen es un menú o una foto de comida, por favor tradúcelo, descríbelo y haz una recomendación.
-Si no parece relacionado con comida, simplemente dilo.
-
-{question}
-''',
-        'fr': '''[Location Memo]
-{promptContext}
-
-Si cette image est un menu ou une photo de nourriture, veuillez la traduire, la décrire et faire une recommandation.
-Si cela ne semble pas lié à la nourriture, dites-le simplement.
-
-{question}
-''',
-        'vi': '''[Location Memo]
-{promptContext}
-
-Nếu hình ảnh này là thực đơn hoặc ảnh món ăn, vui lòng dịch, mô tả và gợi ý.
-Nếu không liên quan đến thực phẩm, chỉ cần nói vậy.
-
-{question}
-''',
-        'th': '''[Location Memo]
-{promptContext}
-
-หากภาพนี้เป็นเมนูอาหารหรือภาพอาหาร โปรดแปล อธิบาย และแนะนำ
-หากดูไม่เกี่ยวกับอาหาร โปรดบอกด้วย
-
-{question}
-''',
-        'ar': '''[Location Memo]
-{promptContext}
-
-إذا كانت هذه الصورة قائمة طعام أو صورة طعام، يرجى ترجمتها ووصفها وتقديم التوصيات.
-إذا لم تكن لها علاقة بالطعام، فقط قل ذلك.
-
-{question}
-''',
-        'bn': '''[Location Memo]
-{promptContext}
-
-এই ছবিটি যদি খাবারের মেনু বা খাবারের ছবি হয়, অনুগ্রহ করে এটি অনুবাদ করুন, বর্ণনা করুন এবং সুপারিশ করুন।
-যদি এটি খাবারের সাথে সম্পর্কিত না হয়, তাহলে শুধু বলুন।
-
-{question}
-''',
-        'ru': '''[Location Memo]
-{promptContext}
-
-Если это изображение меню или фотографии еды, пожалуйста, переведите, опишите и дайте рекомендации.
-Если это не связано с едой, просто скажите об этом.
-
-{question}
-''',
-        'pt': '''[Location Memo]
-{promptContext}
-
-Se esta imagem for um menu de comida ou foto de comida, por favor, traduza, descreva e recomende.
-Se não parecer relacionado à comida, apenas diga isso.
-
-{question}
-''',
-        'pt-BR': '''[Location Memo]
-{promptContext}
-
-Se esta imagem for um cardápio ou uma foto de comida, por favor, traduza, descreva e recomende.
-Se não parecer relacionado à comida, apenas diga isso.
-
-{question}
-''',
-        'ur': '''[Location Memo]
-{promptContext}
-
-اگر یہ تصویر کھانے کے مینو یا کھانے کی تصویر ہے تو براہ کرم اس کا ترجمہ کریں، وضاحت کریں اور سفارش کریں۔
-اگر یہ کھانے سے متعلق نہیں لگتا تو صرف اتنا کہہ دیں۔
-
-{question}
-''',
-        'id': '''[Location Memo]
-{promptContext}
-
-Jika gambar ini adalah menu makanan atau foto makanan, silakan terjemahkan, jelaskan, dan rekomendasikan.
-Jika tidak tampak terkait dengan makanan, cukup katakan saja.
-
-{question}
-''',
-        'de': '''[Location Memo]
-{promptContext}
-
-Wenn dieses Bild ein Speisekarte oder Essensfoto ist, bitte übersetzen, beschreiben und empfehlen.
-Wenn es nicht mit Essen zu tun hat, sagen Sie es einfach.
-
-{question}
-''',
-        'mr': '''[Location Memo]
-{promptContext}
-
-हे चित्र अन्न मेनू किंवा अन्नाचे छायाचित्र असल्यास, कृपया त्याचे भाषांतर करा, वर्णन करा आणि शिफारस करा.
-जर ते अन्नाशी संबंधित वाटत नसेल तर फक्त तसेच सांगा.
-
-{question}
-''',
-        'te': '''[Location Memo]
-{promptContext}
-
-ఈ చిత్రం ఆహార మెనూ లేదా ఆహార ఫోటో అయితే, దయచేసి అనువదించండి, వివరించండి మరియు సిఫార్సు చేయండి.
-అది ఆహారంతో సంబంధం లేకపోతే, కేవలం అలా చెప్పండి.
-
-{question}
-''',
-        'tr': '''[Location Memo]
-{promptContext}
-
-Bu resim bir yemek menüsü veya yemek fotoğrafıysa, lütfen çevirin, açıklayın ve önerin.
-Yemekle ilgili görünmüyorsa, sadece belirtin.
-
-{question}
-''',
-      };
-
-
-// 2) contentList에 mergedPrompt(텍스트)와 이미지(blocl)만 담습니다.
+      // 1) 스캔 모드별 Vision prompt를 분리해서 구성합니다.
       final langCode = await SettingsHelper.getLanguageCode();
+      final mergedPromptWithProtocol = buildVisionPrompt(
+        scanMode: scanMode,
+        targetLanguage: langCode,
+        promptContext: _resolvePromptContext(promptContext),
+        question: question,
+        photoCount: photoCount,
+      );
 
-// ragPrefixMap에서 해당 언어 템플릿 가져와서 context, question 대체
-      final template = ragPrefixMap[langCode] ?? ragPrefixMap['en']!;
-      final mergedPrompt = template
-          .replaceAll('{promptContext}', _resolvePromptContext(promptContext))
-          .replaceAll('{question}', question ?? '');
-
-      final mergedPromptWithProtocol = _streamProtocol + "\n" + mergedPrompt;
-
-
+// 2) contentList에 mode-specific prompt(텍스트)와 이미지(block)만 담습니다.
       final List<Map<String, dynamic>> contentList = [
         {
           'type': 'text',
@@ -258,7 +72,7 @@ Yemekle ilgili görünmüyorsa, sadece belirtin.
 
 
       final tReq0 = DateTime.now();
-      print('🚀 [Vision] request start ${tReq0.toIso8601String()} maxTokens=$maxOutputTokens model=gpt-5-mini rag=$_useRag');
+      print('🚀 [Vision] request start ${tReq0.toIso8601String()} maxTokens=$maxOutputTokens model=gpt-5-mini rag=$_useRag scanMode=${scanMode.wireName} photoCount=$photoCount');
 
       final response = await http.post(
         Uri.parse('https://api.openai.com/v1/chat/completions'),
@@ -298,66 +112,23 @@ Yemekle ilgili görünmüyorsa, sadece belirtin.
       File imageFile, {
         String? promptContext,
         int maxOutputTokens = 3000,
+        ScanMode scanMode = ScanMode.single,
+        int photoCount = 1,
       }) async* {
     final bytes = await imageFile.readAsBytes();
     final base64Image = base64Encode(bytes);
 
     final presetId = await SettingsHelper.getPreset();
     final question = await SettingsHelper.getQuestionByPreset(presetId);
-
-    const String _streamProtocol = '''[OUTPUT PROTOCOL]
-Output exactly ONE JSON object using the existing app schema.
-- No RECOMMEND line
-- No markdown
-- No code fences
-- No extra text
-- Keep the JSON key order as: isMenu, outputLanguage, place, recommended, fullMenu
-''';
-
     final lang = (await SettingsHelper.getLanguageCode()).toString();
 
-    // same templates as analyzeImage (subset; unknown langs fall back to en)
-    final Map<String, String> ragPrefixMap = {
-      'ko': '''[장소 메모]
-{promptContext}
-
-이 이미지가 음식 메뉴나 음식 사진이라면, 내용을 번역하고 설명 및 추천해 주세요.
-음식과 관련 없어 보이면 그렇게 말씀해 주세요.
-
-{question}
-''',
-      'en': '''[Location Memo]
-{promptContext}
-
-If this image is a food menu or food photo, please translate, describe, and recommend it.
-If it doesn’t seem food-related, just say so.
-
-{question}
-''',
-      'ja': '''[Location Memo]
-{promptContext}
-
-この画像が料理のメニューや料理の写真であれば、翻訳して説明し、推薦してください。
-食べ物に関係がないようであれば、そのように言ってください。
-
-{question}
-''',
-      'zh': '''[Location Memo]
-{promptContext}
-
-如果此图像是食物菜单或食物照片，请翻译、描述并推荐。
-如果看起来与食物无关，请指出。
-
-{question}
-''',
-    };
-
-    final template = ragPrefixMap[lang] ?? ragPrefixMap['en']!;
-    final mergedPrompt = template
-        .replaceAll('{promptContext}', _resolvePromptContext(promptContext))
-        .replaceAll('{question}', question ?? '');
-
-    final mergedPromptWithProtocol = _streamProtocol + "\n" + mergedPrompt;
+    final mergedPromptWithProtocol = buildVisionPrompt(
+      scanMode: scanMode,
+      targetLanguage: lang,
+      promptContext: _resolvePromptContext(promptContext),
+      question: question,
+      photoCount: photoCount,
+    );
 
     final List<Map<String, dynamic>> contentList = [
       {'type': 'text', 'text': mergedPromptWithProtocol},

--- a/test/result_parsing_service_test.dart
+++ b/test/result_parsing_service_test.dart
@@ -1,0 +1,108 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mscanner/screens/result/result_parsing_service.dart';
+
+void main() {
+  test('parses multi scan JSON with photo analyses and merged result', () {
+    final response = jsonEncode({
+      'isMenu': true,
+      'scanMode': 'multi',
+      'outputLanguage': 'en',
+      'recommended': [],
+      'fullMenu': {
+        'items': {
+          'main': [],
+          'side': [],
+          'meal': [],
+          'drink': [],
+          'beverage': [],
+          'unknown': []
+        },
+        'summary': '',
+        'truncated': false,
+      },
+      'photoAnalyses': [
+        {
+          'photoIndex': 1,
+          'detectedSections': ['main'],
+          'itemCount': 8,
+          'readableItemCount': 8,
+          'unclearItemCount': 0,
+          'items': [],
+        },
+        {
+          'photoIndex': 2,
+          'detectedSections': ['drinks'],
+          'itemCount': 5,
+          'readableItemCount': 3,
+          'unclearItemCount': 2,
+          'items': [],
+        },
+      ],
+      'mergedResult': {
+        'totalPhotoCount': 2,
+        'totalItemCount': 13,
+        'uniqueItemCount': 12,
+        'duplicateItemCount': 1,
+        'recommendedItems': [],
+        'signatureItems': [],
+        'popularItems': [],
+        'localInsights': [],
+      },
+    });
+
+    final parsed = ResultParsingService.parseAiJson(
+      responses: [response],
+      imageCount: 2,
+    );
+
+    expect(parsed.aiJson?['scanMode'], 'multi');
+    expect(ResultParsingService.getPhotoAnalyses(parsed.aiJson), hasLength(2));
+    final merged = ResultParsingService.getMergedResult(
+      parsed.aiJson,
+      fallbackPhotoCount: 2,
+    );
+    expect(merged['totalItemCount'], 13);
+    expect(merged['uniqueItemCount'], 12);
+    expect(merged['duplicateItemCount'], 1);
+  });
+
+  test('legacy multi response without photoAnalyses does not crash', () {
+    final response = jsonEncode({
+      'isMenu': true,
+      'outputLanguage': 'en',
+      'recommended': [
+        {'id': 'm1', 'nameOriginal': 'Taco', 'name': 'Taco'}
+      ],
+      'fullMenu': {
+        'items': {
+          'main': [
+            {'id': 'm2', 'nameOriginal': 'Burrito', 'name': 'Burrito'}
+          ],
+          'side': [],
+          'meal': [],
+          'drink': [],
+          'beverage': [],
+          'unknown': []
+        },
+        'summary': '',
+        'truncated': false,
+      },
+    });
+
+    final parsed = ResultParsingService.parseAiJson(
+      responses: [response],
+      imageCount: 3,
+    );
+
+    expect(parsed.aiJson?['scanMode'], 'multi');
+    expect(ResultParsingService.getPhotoAnalyses(parsed.aiJson), isEmpty);
+    final merged = ResultParsingService.getMergedResult(
+      parsed.aiJson,
+      fallbackPhotoCount: 3,
+    );
+    expect(merged['totalPhotoCount'], 3);
+    expect(merged['uniqueItemCount'], 2);
+  });
+}

--- a/test/result_parsing_service_test.dart
+++ b/test/result_parsing_service_test.dart
@@ -105,4 +105,98 @@ void main() {
     expect(merged['totalPhotoCount'], 3);
     expect(merged['uniqueItemCount'], 2);
   });
+
+  test('uses mergedResult recommendedItems when top-level recommended is empty', () {
+    final response = jsonEncode({
+      'isMenu': true,
+      'scanMode': 'multi',
+      'outputLanguage': 'ko',
+      'recommended': [],
+      'photoAnalyses': [],
+      'mergedResult': {
+        'totalPhotoCount': 2,
+        'recommendedItems': [
+          {
+            'originalName': '豚骨ラーメン',
+            'translatedName': '돈코츠 라멘',
+            'description': '돼지뼈 육수 기반 라멘',
+            'price': '980円',
+            'reason': '대표 메뉴',
+          }
+        ],
+      },
+    });
+
+    final parsed = ResultParsingService.parseAiJson(
+      responses: [response],
+      imageCount: 2,
+    );
+
+    final recommended = ResultParsingService.getRecommendedItems(parsed.aiJson);
+    expect(recommended, isNotEmpty);
+    expect(recommended.first['nameOriginal'], '豚骨ラーメン');
+    expect(recommended.first['name'], '돈코츠 라멘');
+    expect(recommended.first['shortDesc'], '돼지뼈 육수 기반 라멘');
+  });
+
+  test('photo analysis itemCount falls back to items length', () {
+    final response = jsonEncode({
+      'isMenu': true,
+      'scanMode': 'multi',
+      'photoAnalyses': [
+        {
+          'photoIndex': 1,
+          'itemCount': 0,
+          'readableItemCount': 0,
+          'unclearItemCount': 0,
+          'items': [
+            {'originalName': 'Ramen', 'translatedName': '라멘'},
+            {'originalName': 'Gyoza', 'translatedName': '교자'},
+          ],
+        }
+      ],
+      'mergedResult': {'totalPhotoCount': 1},
+    });
+
+    final parsed = ResultParsingService.parseAiJson(
+      responses: [response],
+      imageCount: 1,
+    );
+
+    final analyses = ResultParsingService.getPhotoAnalyses(parsed.aiJson);
+    expect(analyses, hasLength(1));
+    expect(analyses.first['itemCount'], 2);
+    expect(analyses.first['readableItemCount'], 2);
+  });
+
+  test('readableItemCount falls back to itemCount minus unclearItemCount', () {
+    final response = jsonEncode({
+      'isMenu': true,
+      'scanMode': 'multi',
+      'photoAnalyses': [
+        {
+          'photoIndex': 1,
+          'itemCount': 3,
+          'unclearItemCount': 1,
+          'items': [
+            {'originalName': 'A'},
+            {'originalName': 'B'},
+            {'originalName': 'C'},
+          ],
+        }
+      ],
+      'mergedResult': {'totalPhotoCount': 1},
+    });
+
+    final parsed = ResultParsingService.parseAiJson(
+      responses: [response],
+      imageCount: 1,
+    );
+
+    final analyses = ResultParsingService.getPhotoAnalyses(parsed.aiJson);
+    expect(analyses.first['itemCount'], 3);
+    expect(analyses.first['unclearItemCount'], 1);
+    expect(analyses.first['readableItemCount'], 2);
+  });
+
 }


### PR DESCRIPTION
### Motivation
- Make single-scan and multi-scan Vision prompts explicit and separate so the model follows different analysis flows for one photo vs multiple photos. 
- Preserve existing single-scan JSON schema/behavior for UI compatibility while adding additive multi-scan fields so legacy responses remain supported.
- Improve multi-scan reliability by (a) instructing per-photo analysis → merge → dedupe only at merge stage, and (b) letting the model identify photoIndex when the app supplies a labeled merged image.

### Description
- Added a typed `ScanMode` enum and helper (`lib/models/scan_mode.dart`) to represent `single` vs `multi` scan modes. 
- Created `buildVisionPrompt()` and separate prompt builders `buildSingleScanPrompt()` / `buildMultiScanPrompt()` in `lib/screens/vision_prompt_builder.dart` and wired them into Vision calls so prompts are mode-specific. 
- Updated `VisionService.analyzeImage()` and `analyzeImageStream()` to accept `scanMode` and `photoCount` and to send the mode-specific prompt to the model (`lib/screens/vision_service.dart`). 
- Kept the existing single-scan prompt semantics to preserve UI compatibility; multi-scan prompt enforces the requested analysis order and includes the required `photoAnalyses` / `mergedResult` additive JSON structure. 
- Kept merge-images behavior but modified `ImageMergeService.mergeAndCompress()` to draw per-photo labels (`[PHOTO 1]`, `[PHOTO 2]`, ...) on merged collages so the AI can reliably map items to photoIndex (`lib/screens/image_merge_service.dart`). 
- Loading flow changes: `LoadingScreen` now computes `scanMode`/`photoCount` when preparing inputs and passes them to Vision calls for both streaming and fallback flows (`lib/screens/Loading_Screen.dart`). Also fixed a couple of mounted checks to avoid setState/navigation after dispose. 
- Parsing/compatibility: extended `ResultParsingService` with multi-scan normalization helpers that safely handle optional `photoAnalyses` and `mergedResult`, synthesize sensible fallbacks, and map `photoAnalyses.items` into `fullMenu.items.unknown` when legacy `fullMenu` is missing (`lib/screens/result/result_parsing_service.dart`). 
- Result UI: added a small debug-safe multi-scan summary card (photo-by-photo detected counts / unclear counts / merged totals) and additive Firestore save fields (`scanMode`, `photoCount`, `photoAnalyses`, `mergedResult`, counts) without breaking existing save schema (`lib/screens/Result_Screen.dart`). 
- Unit test: added `test/result_parsing_service_test.dart` to validate new parsing normalization for a canonical multi-scan JSON and for legacy multi responses without `photoAnalyses`.

Files changed/added (key):
- Added: `lib/models/scan_mode.dart`, `lib/screens/vision_prompt_builder.dart`, `test/result_parsing_service_test.dart`.
- Modified: `lib/screens/vision_service.dart`, `lib/screens/Loading_Screen.dart`, `lib/screens/image_merge_service.dart`, `lib/screens/result/result_parsing_service.dart`, `lib/screens/Result_Screen.dart`.

### Testing
- `git diff --check` passed locally in the rollout environment. (OK)
- Added unit test file `test/result_parsing_service_test.dart` that validates: parsing a multi JSON with `photoAnalyses` + `mergedResult`, and legacy responses without `photoAnalyses` do not crash and produce reasonable merged counts. (Test added but not executed in this environment.)
- Attempted `flutter analyze` but it could not be run in this environment because the `flutter` executable is not installed here (`flutter: command not found`). (NOT RUN)
- Attempted `flutter test` for the new unit test but it could not be run for the same reason (`flutter: command not found`). (NOT RUN)

Notes / remaining risks
- Please run `flutter analyze` and `flutter test` locally / in CI to verify formatting, lints and unit tests under a real Flutter SDK; the rollout environment here lacked the Flutter tool. 
- Confirm runtime behavior on device/emulator for streaming vs fallback flows and for Firestore save compatibility (non-destructive additive fields were used). 
- If you later switch from merged-image submission to a multi-image API, remove the merge-label fallback in `ImageMergeService` and pass `images` directly while still passing `scanMode=ScanMode.multi` and `photoCount` to the prompt builder.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b9c0169d8832ebf944d3acda5d2de)