### PR TITLE
PR12: Add AI access protection and App Check foundation

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -4,6 +4,7 @@
     "lint": "eslint --ext .js,.ts .",
     "build": "tsc",
     "test:vision-request": "npm run build && node lib/ai/visionRequest.test.js && node lib/ai/visionMulti.test.js && node lib/ai/visionSingle.test.js",
+    "test:ai-access": "npm run build && node lib/ai/aiEntitlementService.test.js && node lib/ai/aiQuotaService.test.js && node lib/ai/aiAccessPolicyService.test.js",
     "build:watch": "tsc --watch",
     "serve": "npm run build && firebase emulators:start --only functions",
     "shell": "npm run build && firebase functions:shell",

--- a/functions/src/ai/aiAccessConfig.ts
+++ b/functions/src/ai/aiAccessConfig.ts
@@ -1,0 +1,24 @@
+export type AiEntitlementTier = "free" | "premium";
+export type AiScanMode = "single" | "multi";
+
+// PR12 only lays down the quota foundation. Enforcement is intentionally off
+// until production metrics have been observed and a separate rollout changes it.
+export const AI_QUOTA_ENFORCEMENT_ENABLED = false;
+export const AI_QUOTA_TIME_ZONE = "UTC";
+export interface AiQuotaLimits {
+  free: number | null;
+  premium: number | null;
+}
+
+export const AI_QUOTA_LIMITS: AiQuotaLimits = {
+  free: null,
+  premium: null,
+};
+
+export function dailyQuotaForTier(tier: AiEntitlementTier): number | null {
+  return AI_QUOTA_LIMITS[tier];
+}
+
+export function utcDayKey(now: Date = new Date()): string {
+  return now.toISOString().slice(0, 10);
+}

--- a/functions/src/ai/aiAccessPolicyService.test.ts
+++ b/functions/src/ai/aiAccessPolicyService.test.ts
@@ -1,0 +1,82 @@
+import assert from "node:assert/strict";
+
+import {
+  beginAiAccessObservation,
+  resolveAndReserveAiAccess,
+} from "./aiAccessPolicyService";
+
+void (async () => {
+  const context = beginAiAccessObservation({
+    auth: {uid: "uid"},
+    app: {appId: "firebase-app"},
+    data: {requestId: "vision-123"},
+  });
+  assert.deepEqual(context, {uid: "uid", requestId: "vision-123"});
+
+  const missingAppCheck = beginAiAccessObservation({
+    auth: {uid: "uid"},
+    data: {requestId: "vision-124"},
+  });
+  assert.equal(missingAppCheck.uid, "uid");
+
+  assert.throws(
+    () => beginAiAccessObservation({data: {requestId: "unauthenticated"}}),
+    (error: unknown) => error instanceof Error
+  );
+
+  const allowed = await resolveAndReserveAiAccess(
+    context,
+    "single",
+    {
+      resolveEntitlement: async () => ({
+        tier: "free",
+        premiumActive: false,
+        source: "missing_user_points",
+      }),
+      reserveQuota: async (_uid, tier, scanMode) => ({
+        allowed: true,
+        enforced: false,
+        dayKey: "2026-08-29",
+        tier,
+        scanMode,
+        limit: null,
+        usedCount: 0,
+      }),
+    }
+  );
+  assert.equal(allowed.entitlement.tier, "free");
+  assert.equal(allowed.quota.allowed, true);
+
+  await assert.rejects(
+    () => resolveAndReserveAiAccess(
+      context,
+      "multi",
+      {
+        resolveEntitlement: async () => ({
+          tier: "premium",
+          premiumActive: true,
+          source: "user_points.premium",
+        }),
+        reserveQuota: async (_uid, tier, scanMode) => ({
+          allowed: false,
+          enforced: true,
+          dayKey: "2026-08-29",
+          tier,
+          scanMode,
+          limit: 1,
+          usedCount: 1,
+        }),
+      }
+    ),
+    (error: unknown) => {
+      return error instanceof Error &&
+      "code" in error &&
+      error.code === "resource-exhausted";
+    }
+  );
+
+  console.log("aiAccessPolicyService tests passed");
+})().catch((error: unknown) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/functions/src/ai/aiAccessPolicyService.ts
+++ b/functions/src/ai/aiAccessPolicyService.ts
@@ -1,0 +1,104 @@
+import {HttpsError} from "firebase-functions/v2/https";
+
+import {AiEntitlementTier, AiScanMode} from "./aiAccessConfig";
+import {AiEntitlement} from "./aiEntitlementService";
+
+export interface AiCallableRequest {
+  auth?: unknown;
+  app?: unknown;
+  data?: unknown;
+}
+
+export interface AiAccessContext {
+  uid: string;
+  requestId: string | null;
+}
+
+export interface AiAccessDecision {
+  context: AiAccessContext;
+  entitlement: AiEntitlement;
+  quota: {
+    allowed: boolean;
+    enforced: boolean;
+    dayKey: string;
+    tier: AiEntitlementTier;
+    scanMode: AiScanMode;
+    limit: number | null;
+    usedCount: number;
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function normalizeAiRequestId(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const requestId = value.trim();
+  if (!requestId || requestId.length > 64 ||
+      !/^[A-Za-z0-9._:-]+$/.test(requestId)) {
+    return null;
+  }
+  return requestId;
+}
+
+function authUid(value: unknown): string | null {
+  if (!isRecord(value) || typeof value.uid !== "string") return null;
+  const uid = value.uid.trim();
+  return uid ? uid : null;
+}
+
+/** Validate auth and observe App Check without enforcing it. */
+export function beginAiAccessObservation(
+  request: AiCallableRequest
+): AiAccessContext {
+  const uid = authUid(request.auth);
+  if (uid === null) {
+    throw new HttpsError("unauthenticated", "Login required.");
+  }
+
+  const data = isRecord(request.data) ? request.data : {};
+  const requestId = normalizeAiRequestId(data.requestId);
+  const appCheckState = request.app !== undefined && request.app !== null ?
+    "valid" :
+    "missing_or_invalid";
+  const label = requestId ?? "no-request-id";
+  console.log(
+    "[AI Access][" + label + "] appCheck=" + appCheckState
+  );
+
+  return {uid, requestId};
+}
+
+/**
+ * Resolve entitlement and reserve quota immediately before the OpenAI call.
+ * Dependencies are injected to keep the policy unit-testable.
+ */
+export async function resolveAndReserveAiAccess(
+  context: AiAccessContext,
+  scanMode: AiScanMode,
+  dependencies: {
+    resolveEntitlement: (uid: string) => Promise<AiEntitlement>;
+    reserveQuota: (
+      uid: string,
+      tier: AiEntitlementTier,
+      scanMode: AiScanMode
+    ) => Promise<AiAccessDecision["quota"]>;
+  }
+): Promise<AiAccessDecision> {
+  const entitlement = await dependencies.resolveEntitlement(context.uid);
+  const quota = await dependencies.reserveQuota(
+    context.uid,
+    entitlement.tier,
+    scanMode
+  );
+
+  if (!quota.allowed) {
+    throw new HttpsError(
+      "resource-exhausted",
+      "Daily AI quota exceeded."
+    );
+  }
+
+  return {context, entitlement, quota};
+}

--- a/functions/src/ai/aiEntitlementService.test.ts
+++ b/functions/src/ai/aiEntitlementService.test.ts
@@ -1,0 +1,109 @@
+import assert from "node:assert/strict";
+import * as admin from "firebase-admin";
+
+import {
+  resolveAiEntitlement,
+} from "./aiEntitlementService";
+
+void (async () => {
+type UserPointsData = Record<string, unknown> | undefined;
+
+function fakeFirestore(data: UserPointsData): admin.firestore.Firestore {
+  return {
+    collection: () => ({
+      doc: () => ({
+        get: async () => ({
+          exists: data !== undefined,
+          data: () => data,
+        }),
+      }),
+    }),
+  } as unknown as admin.firestore.Firestore;
+}
+
+const now = new Date("2026-08-29T00:00:00.000Z");
+const future = admin.firestore.Timestamp.fromDate(
+  new Date("2026-08-30T00:00:00.000Z")
+);
+const past = admin.firestore.Timestamp.fromDate(
+  new Date("2026-08-28T00:00:00.000Z")
+);
+
+const noDocument = await resolveAiEntitlement(
+  "uid",
+  {firestore: fakeFirestore(undefined), now}
+);
+assert.deepEqual(noDocument, {
+  tier: "free",
+  premiumActive: false,
+  source: "missing_user_points",
+});
+
+const active = await resolveAiEntitlement(
+  "uid",
+  {
+    firestore: fakeFirestore({
+      premium: {status: "active", expiresAt: future},
+    }),
+    now,
+  }
+);
+assert.equal(active.tier, "premium");
+assert.equal(active.premiumActive, true);
+assert.equal(active.source, "user_points.premium");
+
+const expired = await resolveAiEntitlement(
+  "uid",
+  {
+    firestore: fakeFirestore({
+      premium: {status: "active", expiresAt: past},
+    }),
+    now,
+  }
+);
+assert.equal(expired.tier, "free");
+assert.equal(expired.premiumActive, false);
+
+const canceledButEntitled = await resolveAiEntitlement(
+  "uid",
+  {
+    firestore: fakeFirestore({
+      premium: {status: "canceled", expiresAt: future},
+    }),
+    now,
+  }
+);
+assert.equal(canceledButEntitled.premiumActive, true);
+
+const legacyActive = await resolveAiEntitlement(
+  "uid",
+  {firestore: fakeFirestore({premiumExpiry: future}), now}
+);
+assert.equal(legacyActive.tier, "premium");
+assert.equal(legacyActive.source, "user_points.premiumExpiry");
+
+const legacyExpired = await resolveAiEntitlement(
+  "uid",
+  {firestore: fakeFirestore({premiumExpiry: past}), now}
+);
+assert.equal(legacyExpired.tier, "free");
+
+// Client-style flags do not participate in server entitlement resolution.
+const clientFlagIgnored = await resolveAiEntitlement(
+  "uid",
+  {
+    firestore: fakeFirestore({
+      premium: {status: "expired"},
+      isPremium: true,
+      isSubscribed: true,
+    }),
+    now,
+  }
+);
+assert.equal(clientFlagIgnored.tier, "free");
+
+console.log("aiEntitlementService tests passed");
+})().catch((error: unknown) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/functions/src/ai/aiEntitlementService.ts
+++ b/functions/src/ai/aiEntitlementService.ts
@@ -1,0 +1,97 @@
+import * as admin from "firebase-admin";
+
+import {AiEntitlementTier} from "./aiAccessConfig";
+
+export type AiEntitlementSource =
+  | "user_points.premium"
+  | "user_points.premiumExpiry"
+  | "missing_user_points"
+  | "invalid_user_points";
+
+export interface AiEntitlement {
+  tier: AiEntitlementTier;
+  premiumActive: boolean;
+  source: AiEntitlementSource;
+}
+
+export interface ResolveAiEntitlementOptions {
+  firestore?: admin.firestore.Firestore;
+  now?: Date;
+}
+
+function toDate(value: unknown): Date | null {
+  if (value instanceof Date) return value;
+  if (typeof value === "number" || typeof value === "string") {
+    const date = new Date(value);
+    return Number.isNaN(date.getTime()) ? null : date;
+  }
+  if (typeof value === "object" && value !== null &&
+      "toDate" in value && typeof value.toDate === "function") {
+    const date = value.toDate();
+    return date instanceof Date && !Number.isNaN(date.getTime()) ? date : null;
+  }
+  return null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function premiumResult(
+  active: boolean,
+  source: AiEntitlementSource
+): AiEntitlement {
+  return {
+    tier: active ? "premium" : "free",
+    premiumActive: active,
+    source,
+  };
+}
+
+/**
+ * Resolve AI entitlement from the server-side user_points document only.
+ * Client payload flags such as premium/isPremium/isSubscribed are never read.
+ *
+ * The active/expired semantics intentionally match AdRemoveProvider: a
+ * canceled entitlement remains active until its expiry timestamp, while an
+ * active/grace/pending status without an expiry is treated as active.
+ */
+export async function resolveAiEntitlement(
+  uid: string,
+  options: ResolveAiEntitlementOptions = {}
+): Promise<AiEntitlement> {
+  const firestore = options.firestore ?? admin.firestore();
+  const now = options.now ?? new Date();
+  const snapshot = await firestore.collection("user_points").doc(uid).get();
+
+  if (!snapshot.exists) {
+    return premiumResult(false, "missing_user_points");
+  }
+
+  const data = snapshot.data();
+  if (!isRecord(data)) {
+    return premiumResult(false, "invalid_user_points");
+  }
+
+  const premium = data.premium;
+  if (isRecord(premium)) {
+    const status = typeof premium.status === "string" ?
+      premium.status.toLowerCase() :
+      "expired";
+    const expiresAt = toDate(premium.expiresAt);
+    const entitlementValid = expiresAt !== null && now < expiresAt;
+    const statusActive = status === "active" ||
+      status === "grace" ||
+      status === "pending";
+
+    // A future expiry preserves access even when the subscription is canceled.
+    const active = expiresAt !== null ? entitlementValid : statusActive;
+    return premiumResult(active, "user_points.premium");
+  }
+
+  const legacyExpiry = toDate(data.premiumExpiry);
+  return premiumResult(
+    legacyExpiry !== null && now < legacyExpiry,
+    legacyExpiry === null ? "invalid_user_points" : "user_points.premiumExpiry"
+  );
+}

--- a/functions/src/ai/aiQuotaService.test.ts
+++ b/functions/src/ai/aiQuotaService.test.ts
@@ -1,0 +1,126 @@
+import assert from "node:assert/strict";
+import * as admin from "firebase-admin";
+
+import {
+  AiQuotaReservation,
+  reserveAiQuota,
+} from "./aiQuotaService";
+
+void (async () => {
+interface FakeSnapshot {
+  exists: boolean;
+  data: () => Record<string, unknown>;
+}
+
+interface FakeTransaction {
+  get: (ref: unknown) => Promise<FakeSnapshot>;
+  set: (ref: unknown, data: Record<string, unknown>) => void;
+}
+
+function fakeFirestore(initial: Record<string, unknown> = {}) {
+  let state = {...initial};
+  let exists = Object.keys(initial).length > 0;
+  let transactionCount = 0;
+  let writeCount = 0;
+
+  const firestore = {
+    collection: () => ({
+      doc: () => ({
+        collection: () => ({
+          doc: () => ({}),
+        }),
+      }),
+    }),
+    runTransaction: async (
+      callback: (transaction: FakeTransaction) => Promise<AiQuotaReservation>
+    ): Promise<AiQuotaReservation> => {
+      transactionCount += 1;
+      const transaction: FakeTransaction = {
+        get: async () => ({
+          exists,
+          data: () => state,
+        }),
+        set: (_ref, data) => {
+          writeCount += 1;
+          state = {...state, ...data};
+          exists = true;
+        },
+      };
+      return callback(transaction);
+    },
+  } as unknown as admin.firestore.Firestore;
+
+  return {
+    firestore,
+    state: () => state,
+    transactionCount: () => transactionCount,
+    writeCount: () => writeCount,
+  };
+}
+
+const now = new Date("2026-08-29T00:00:00.000Z");
+const limits = {free: 2, premium: 5};
+const store = fakeFirestore();
+
+const first = await reserveAiQuota(
+  "uid",
+  "free",
+  "single",
+  {firestore: store.firestore, now, limits, enforcementEnabled: true}
+);
+assert.equal(first.allowed, true);
+assert.equal(first.usedCount, 1);
+assert.equal(store.state().singleCount, 1);
+assert.equal(store.state().multiCount, 0);
+
+const second = await reserveAiQuota(
+  "uid",
+  "free",
+  "multi",
+  {firestore: store.firestore, now, limits, enforcementEnabled: true}
+);
+assert.equal(second.allowed, true);
+assert.equal(second.usedCount, 2);
+assert.equal(store.state().singleCount, 1);
+assert.equal(store.state().multiCount, 1);
+
+// A repeated requestId is intentionally not accepted by this API. A repeated
+// call still reaches the transaction and is denied at the limit.
+const repeatedRequest = await reserveAiQuota(
+  "uid",
+  "free",
+  "single",
+  {firestore: store.firestore, now, limits, enforcementEnabled: true}
+);
+assert.equal(repeatedRequest.allowed, false);
+assert.equal(store.writeCount(), 2);
+assert.equal(store.transactionCount(), 3);
+
+const disabled = await reserveAiQuota(
+  "uid",
+  "free",
+  "single",
+  {now}
+);
+assert.equal(disabled.allowed, true);
+assert.equal(disabled.enforced, false);
+
+const newDay = await reserveAiQuota(
+  "uid",
+  "premium",
+  "multi",
+  {
+    firestore: store.firestore,
+    now: new Date("2026-08-30T00:00:00.000Z"),
+    limits,
+    enforcementEnabled: true,
+  }
+);
+assert.equal(newDay.allowed, true);
+assert.equal(newDay.dayKey, "2026-08-30");
+
+console.log("aiQuotaService tests passed");
+})().catch((error: unknown) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/functions/src/ai/aiQuotaService.ts
+++ b/functions/src/ai/aiQuotaService.ts
@@ -1,0 +1,115 @@
+import * as admin from "firebase-admin";
+
+import {
+  AiEntitlementTier,
+  AiQuotaLimits,
+  AiScanMode,
+  AI_QUOTA_ENFORCEMENT_ENABLED,
+  dailyQuotaForTier,
+  utcDayKey,
+} from "./aiAccessConfig";
+
+export interface AiQuotaReservation {
+  allowed: boolean;
+  enforced: boolean;
+  dayKey: string;
+  tier: AiEntitlementTier;
+  scanMode: AiScanMode;
+  limit: number | null;
+  usedCount: number;
+}
+
+export interface ReserveAiQuotaOptions {
+  firestore?: admin.firestore.Firestore;
+  now?: Date;
+  limits?: AiQuotaLimits;
+  enforcementEnabled?: boolean;
+}
+
+function safeCount(value: unknown): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) return 0;
+  return Math.max(0, Math.floor(value));
+}
+
+function quotaRef(
+  firestore: admin.firestore.Firestore,
+  uid: string,
+  dayKey: string
+): admin.firestore.DocumentReference {
+  return firestore.collection("ai_usage").doc(uid).collection("daily").doc(dayKey);
+}
+
+/**
+ * Reserve one AI request inside a Firestore transaction.
+ *
+ * requestId is deliberately absent: it is an observability identifier, not an
+ * idempotency key. Reusing a requestId therefore cannot skip a quota charge.
+ */
+export async function reserveAiQuota(
+  uid: string,
+  tier: AiEntitlementTier,
+  scanMode: AiScanMode,
+  options: ReserveAiQuotaOptions = {}
+): Promise<AiQuotaReservation> {
+  const now = options.now ?? new Date();
+  const dayKey = utcDayKey(now);
+  const limit = options.limits?.[tier] ?? dailyQuotaForTier(tier);
+  const enforced = options.enforcementEnabled ?? AI_QUOTA_ENFORCEMENT_ENABLED;
+
+  if (!enforced || limit === null) {
+    return {
+      allowed: true,
+      enforced: false,
+      dayKey,
+      tier,
+      scanMode,
+      limit,
+      usedCount: 0,
+    };
+  }
+
+  const firestore = options.firestore ?? admin.firestore();
+  const ref = quotaRef(firestore, uid, dayKey);
+  const timestamp = admin.firestore.Timestamp.fromDate(now);
+
+  return firestore.runTransaction(async (transaction) => {
+    const snapshot = await transaction.get(ref);
+    const data = snapshot.exists ? snapshot.data() ?? {} : {};
+    const currentTotal = safeCount(data.totalCount);
+
+    if (currentTotal >= limit) {
+      return {
+        allowed: false,
+        enforced: true,
+        dayKey,
+        tier,
+        scanMode,
+        limit,
+        usedCount: currentTotal,
+      };
+    }
+
+    const singleCount = safeCount(data.singleCount) + (scanMode === "single" ? 1 : 0);
+    const multiCount = safeCount(data.multiCount) + (scanMode === "multi" ? 1 : 0);
+    const nextTotal = currentTotal + 1;
+
+    transaction.set(ref, {
+      dayKey,
+      totalCount: nextTotal,
+      singleCount,
+      multiCount,
+      lastUsedAt: timestamp,
+      updatedAt: timestamp,
+    }, {merge: true});
+
+    return {
+      allowed: true,
+      enforced: true,
+      dayKey,
+      tier,
+      scanMode,
+      limit,
+      usedCount: nextTotal,
+    };
+  });
+}

--- a/functions/src/ai/visionService.ts
+++ b/functions/src/ai/visionService.ts
@@ -18,11 +18,15 @@ import {
   buildVisionImageContent,
   normalizeVisionImages,
 } from "./visionRequest";
+import {resolveAiEntitlement} from "./aiEntitlementService";
+import {reserveAiQuota} from "./aiQuotaService";
+import {
+  AiCallableRequest,
+  beginAiAccessObservation,
+  resolveAndReserveAiAccess,
+} from "./aiAccessPolicyService";
 
-interface VisionCallableRequest {
-  auth?: unknown;
-  data?: unknown;
-}
+type VisionCallableRequest = AiCallableRequest;
 
 interface VisionV2Response {
   success: true;
@@ -154,9 +158,7 @@ export async function handleAnalyzeVisionV2(
   request: VisionCallableRequest,
   apiKey: string
 ): Promise<VisionV2Response> {
-  if (!request.auth) {
-    throw new HttpsError("unauthenticated", "Login required.");
-  }
+  const accessContext = beginAiAccessObservation(request);
 
   const data = isRecord(request.data) ? request.data : {};
   const requestId = normalizeRequestId(data.requestId);
@@ -192,6 +194,15 @@ export async function handleAnalyzeVisionV2(
     `request_received scanMode=${scanMode} inputImageCount=${inputImageCount} ` +
     `sourceImageCount=${sourceImageCount ?? "unknown"} requestFullMenu=${requestFullMenu}`
   );
+  await resolveAndReserveAiAccess(
+    accessContext,
+    scanMode,
+    {
+      resolveEntitlement: resolveAiEntitlement,
+      reserveQuota: reserveAiQuota,
+    }
+  );
+
   const openai = new OpenAI({apiKey});
   const startedAt = Date.now();
 

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -8,6 +8,12 @@ import OpenAI from "openai";
 import { randomUUID } from "crypto";
 import sharp from "sharp";
 import {IMAGE_MODEL} from "./ai/aiConfig";
+import {resolveAiEntitlement} from "./ai/aiEntitlementService";
+import {reserveAiQuota} from "./ai/aiQuotaService";
+import {
+  beginAiAccessObservation,
+  resolveAndReserveAiAccess,
+} from "./ai/aiAccessPolicyService";
 import {handleAnalyzeVisionV2} from "./ai/visionService";
 
 if (admin.apps.length === 0) {
@@ -20,8 +26,9 @@ const OPENAI_API_KEY = defineSecret("OPENAI_API_KEY");
 export const generateMenuImage = onCall(
   { timeoutSeconds: 120, memory: "1GiB", secrets: [OPENAI_API_KEY] },
   async (req) => {
-    const auth = req.auth;
-    if (!auth) throw new HttpsError("unauthenticated", "Login required.");
+    // Cost endpoint audit: observe App Check, but do not change image access
+    // or combine this endpoint with the Vision quota in PR12.
+    beginAiAccessObservation(req);
 
     const { menuKey, menu, shortDesc, tags, searchedMenuDocId } = req.data || {};
     if (!menuKey || typeof menuKey !== "string") {
@@ -407,14 +414,7 @@ export const analyzeVision = onCall(
     secrets: [OPENAI_API_KEY],
   },
   async (req) => {
-    const auth = req.auth;
-
-    if (!auth) {
-      throw new HttpsError(
-        "unauthenticated",
-        "Login required."
-      );
-    }
+    const accessContext = beginAiAccessObservation(req);
 
     const {
       imageBase64,
@@ -449,6 +449,15 @@ export const analyzeVision = onCall(
         maxOutputTokens,
         safeScanMode
       );
+
+    await resolveAndReserveAiAccess(
+      accessContext,
+      safeScanMode,
+      {
+        resolveEntitlement: resolveAiEntitlement,
+        reserveQuota: reserveAiQuota,
+      }
+    );
 
     // 메뉴 분석·번역 모델
     const model = "gpt-5.6-luna";

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -30,6 +30,7 @@ import 'package:provider/provider.dart';
 import 'ad_remove_provider.dart';
 import 'analytics_service.dart';
 import 'helpers/preset_update_review_service.dart';
+import 'services/firebase_app_check_service.dart';
 import 'services/interstitial_ad_service.dart';
 
 enum GuestWelcomeAction {
@@ -44,6 +45,7 @@ void main() async {
   await Firebase.initializeApp(
     options: DefaultFirebaseOptions.currentPlatform,
   );
+  await _activateFirebaseAppCheck();
   await MobileAds.instance.initialize();
 
   final savedThemeMode = await AdaptiveTheme.getThemeMode();
@@ -61,6 +63,16 @@ void main() async {
   );
 
   unawaited(_initializeAfterLaunch());
+}
+
+Future<void> _activateFirebaseAppCheck() async {
+  try {
+    await FirebaseAppCheckService.activate();
+  } catch (error) {
+    // PR12 is observation-only. A provider setup issue must not block launch.
+    final errorType = error.runtimeType;
+    debugPrint('[AppCheck] activation failed: $errorType');
+  }
 }
 
 Future<void> _initializeAfterLaunch() async {

--- a/lib/services/firebase_app_check_service.dart
+++ b/lib/services/firebase_app_check_service.dart
@@ -1,0 +1,26 @@
+import "package:firebase_app_check/firebase_app_check.dart";
+import "package:flutter/foundation.dart";
+
+/// App Check provider selection for the observation-only PR12 rollout.
+class FirebaseAppCheckService {
+  static AndroidAppCheckProvider androidProvider({required bool debug}) {
+    return debug
+        ? const AndroidDebugProvider()
+        : const AndroidPlayIntegrityProvider();
+  }
+
+  static AppleAppCheckProvider appleProvider({required bool debug}) {
+    return debug
+        ? const AppleDebugProvider()
+        : const AppleAppAttestWithDeviceCheckFallbackProvider();
+  }
+
+  static Future<void> activate({bool? debug}) async {
+    final useDebugProvider = debug ?? kDebugMode;
+    await FirebaseAppCheck.instance.activate(
+      providerAndroid: androidProvider(debug: useDebugProvider),
+      providerApple: appleProvider(debug: useDebugProvider),
+    );
+    await FirebaseAppCheck.instance.setTokenAutoRefreshEnabled(true);
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,6 +16,7 @@ dependencies:
   path_provider: ^2.1.5
   cupertino_icons: ^1.0.8
   firebase_core: ^4.1.1
+  firebase_app_check: ^0.4.7
   firebase_analytics: ^12.2.0
   firebase_crashlytics: ^5.0.1
   firebase_remote_config: ^6.1.1

--- a/test/firebase_app_check_provider_test.dart
+++ b/test/firebase_app_check_provider_test.dart
@@ -1,0 +1,33 @@
+import "package:firebase_app_check/firebase_app_check.dart";
+import "package:flutter_test/flutter_test.dart";
+import "package:mscanner/services/firebase_app_check_service.dart";
+
+void main() {
+  test("Android debug selects the debug provider", () {
+    expect(
+      FirebaseAppCheckService.androidProvider(debug: true),
+      isA<AndroidDebugProvider>(),
+    );
+  });
+
+  test("Android release selects Play Integrity", () {
+    expect(
+      FirebaseAppCheckService.androidProvider(debug: false),
+      isA<AndroidPlayIntegrityProvider>(),
+    );
+  });
+
+  test("Apple debug selects the debug provider", () {
+    expect(
+      FirebaseAppCheckService.appleProvider(debug: true),
+      isA<AppleDebugProvider>(),
+    );
+  });
+
+  test("Apple release selects App Attest with Device Check fallback", () {
+    expect(
+      FirebaseAppCheckService.appleProvider(debug: false),
+      isA<AppleAppAttestWithDeviceCheckFallbackProvider>(),
+    );
+  });
+}


### PR DESCRIPTION
## Summary

- Stacked on `agent/vision-v2-structured-output`
- Added Flutter Firebase App Check integration with debug/release provider selection
- Added server-side entitlement resolution from `user_points/{uid}`
- Added atomic UID daily quota foundation under `ai_usage/{uid}/daily/{YYYY-MM-DD}`
- Added App Check observation logging for AI callable endpoints
- Audited `analyzeVision`, `analyzeVisionV2`, and `generateMenuImage`

## Rollout and scope

- App Check enforcement is intentionally OFF; `enforceAppCheck: true` is not enabled
- Quota enforcement is intentionally OFF because no authoritative production limits were found
- Vision semantics, model, prompts, schemas, routing, aggregation, and requestId semantics are unchanged
- No production Firebase deployment was performed
- Client premium flags are not trusted; this PR does not add Apple/Google receipt verification

## Validation

- `flutter analyze`
- `flutter test` (97 tests)
- `npm run lint`
- `npm run build`
- `npm run test:vision-request`
- `npm run test:ai-access`

This is the PR12 development-stage name; the GitHub PR number may differ.