### PR TITLE
PR12.1: Harden premium entitlement trust boundary

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -5,6 +5,7 @@
     "build": "tsc",
     "test:vision-request": "npm run build && node lib/ai/visionRequest.test.js && node lib/ai/visionMulti.test.js && node lib/ai/visionSingle.test.js",
     "test:ai-access": "npm run build && node lib/ai/aiEntitlementService.test.js && node lib/ai/aiQuotaService.test.js && node lib/ai/aiAccessPolicyService.test.js",
+    "test:entitlement": "npm run build && node lib/entitlements/trustedEntitlementService.test.js && node lib/ai/aiEntitlementService.test.js",
     "build:watch": "tsc --watch",
     "serve": "npm run build && firebase emulators:start --only functions",
     "shell": "npm run build && firebase functions:shell",

--- a/functions/src/ai/aiAccessPolicyService.test.ts
+++ b/functions/src/ai/aiAccessPolicyService.test.ts
@@ -31,7 +31,8 @@ void (async () => {
       resolveEntitlement: async () => ({
         tier: "free",
         premiumActive: false,
-        source: "missing_user_points",
+        trust: "none",
+        source: "none",
       }),
       reserveQuota: async (_uid, tier, scanMode) => ({
         allowed: true,
@@ -45,6 +46,7 @@ void (async () => {
     }
   );
   assert.equal(allowed.entitlement.tier, "free");
+  assert.equal(allowed.entitlement.trust, "none");
   assert.equal(allowed.quota.allowed, true);
 
   await assert.rejects(
@@ -55,7 +57,8 @@ void (async () => {
         resolveEntitlement: async () => ({
           tier: "premium",
           premiumActive: true,
-          source: "user_points.premium",
+          trust: "trusted",
+          source: "apple",
         }),
         reserveQuota: async (_uid, tier, scanMode) => ({
           allowed: false,

--- a/functions/src/ai/aiAccessPolicyService.ts
+++ b/functions/src/ai/aiAccessPolicyService.ts
@@ -87,6 +87,13 @@ export async function resolveAndReserveAiAccess(
   }
 ): Promise<AiAccessDecision> {
   const entitlement = await dependencies.resolveEntitlement(context.uid);
+  const label = context.requestId ?? "no-request-id";
+  console.log(
+    "[AI Access][" + label + "] entitlementTrust=" + entitlement.trust +
+    " tier=" + entitlement.tier +
+    " source=" + entitlement.source
+  );
+
   const quota = await dependencies.reserveQuota(
     context.uid,
     entitlement.tier,

--- a/functions/src/ai/aiEntitlementService.test.ts
+++ b/functions/src/ai/aiEntitlementService.test.ts
@@ -5,104 +5,232 @@ import {
   resolveAiEntitlement,
 } from "./aiEntitlementService";
 
-void (async () => {
-type UserPointsData = Record<string, unknown> | undefined;
+type DocumentData = Record<string, unknown> | undefined;
 
-function fakeFirestore(data: UserPointsData): admin.firestore.Firestore {
+function fakeFirestore(
+  dataByCollection: Record<string, DocumentData>
+): admin.firestore.Firestore {
   return {
-    collection: () => ({
+    collection: (name: string) => ({
       doc: () => ({
-        get: async () => ({
-          exists: data !== undefined,
-          data: () => data,
-        }),
+        get: async () => {
+          const data = dataByCollection[name];
+          return {
+            exists: data !== undefined,
+            data: () => data,
+          };
+        },
       }),
     }),
   } as unknown as admin.firestore.Firestore;
 }
 
-const now = new Date("2026-08-29T00:00:00.000Z");
-const future = admin.firestore.Timestamp.fromDate(
-  new Date("2026-08-30T00:00:00.000Z")
-);
-const past = admin.firestore.Timestamp.fromDate(
-  new Date("2026-08-28T00:00:00.000Z")
-);
+void (async () => {
+  const now = new Date("2026-08-29T00:00:00.000Z");
+  const future = admin.firestore.Timestamp.fromDate(
+    new Date("2026-08-30T00:00:00.000Z")
+  );
+  const past = admin.firestore.Timestamp.fromDate(
+    new Date("2026-08-28T00:00:00.000Z")
+  );
+  const verifiedAt = admin.firestore.Timestamp.fromDate(now);
 
-const noDocument = await resolveAiEntitlement(
-  "uid",
-  {firestore: fakeFirestore(undefined), now}
-);
-assert.deepEqual(noDocument, {
-  tier: "free",
-  premiumActive: false,
-  source: "missing_user_points",
-});
+  const trustedDocument = {
+    premium: {
+      status: "active",
+      expiresAt: future,
+      verifiedAt,
+      source: "apple",
+      productId: "premium.monthly",
+    },
+    updatedAt: verifiedAt,
+  };
 
-const active = await resolveAiEntitlement(
-  "uid",
-  {
-    firestore: fakeFirestore({
-      premium: {status: "active", expiresAt: future},
-    }),
-    now,
-  }
-);
-assert.equal(active.tier, "premium");
-assert.equal(active.premiumActive, true);
-assert.equal(active.source, "user_points.premium");
+  const noDocument = await resolveAiEntitlement(
+    "uid",
+    {firestore: fakeFirestore({}), now}
+  );
+  assert.deepEqual(noDocument, {
+    tier: "free",
+    premiumActive: false,
+    trust: "none",
+    source: "none",
+  });
 
-const expired = await resolveAiEntitlement(
-  "uid",
-  {
-    firestore: fakeFirestore({
-      premium: {status: "active", expiresAt: past},
-    }),
-    now,
-  }
-);
-assert.equal(expired.tier, "free");
-assert.equal(expired.premiumActive, false);
+  const userPointsOnly = await resolveAiEntitlement(
+    "uid",
+    {
+      firestore: fakeFirestore({
+        user_points: {
+          premium: {status: "active", expiresAt: future},
+          isPremium: true,
+          isSubscribed: true,
+        },
+      }),
+      now,
+    }
+  );
+  assert.deepEqual(userPointsOnly, {
+    tier: "free",
+    premiumActive: false,
+    trust: "none",
+    source: "none",
+  });
 
-const canceledButEntitled = await resolveAiEntitlement(
-  "uid",
-  {
-    firestore: fakeFirestore({
-      premium: {status: "canceled", expiresAt: future},
-    }),
-    now,
-  }
-);
-assert.equal(canceledButEntitled.premiumActive, true);
+  const active = await resolveAiEntitlement(
+    "uid",
+    {firestore: fakeFirestore({
+      server_entitlements: trustedDocument,
+    }), now}
+  );
+  assert.deepEqual(active, {
+    tier: "premium",
+    premiumActive: true,
+    trust: "trusted",
+    source: "apple",
+  });
 
-const legacyActive = await resolveAiEntitlement(
-  "uid",
-  {firestore: fakeFirestore({premiumExpiry: future}), now}
-);
-assert.equal(legacyActive.tier, "premium");
-assert.equal(legacyActive.source, "user_points.premiumExpiry");
+  const grace = await resolveAiEntitlement(
+    "uid",
+    {
+      firestore: fakeFirestore({
+        server_entitlements: {
+          ...trustedDocument,
+          premium: {...trustedDocument.premium, status: "grace"},
+        },
+      }),
+      now,
+    }
+  );
+  assert.equal(grace.premiumActive, true);
+  assert.equal(grace.trust, "trusted");
 
-const legacyExpired = await resolveAiEntitlement(
-  "uid",
-  {firestore: fakeFirestore({premiumExpiry: past}), now}
-);
-assert.equal(legacyExpired.tier, "free");
+  const canceledButEntitled = await resolveAiEntitlement(
+    "uid",
+    {
+      firestore: fakeFirestore({
+        server_entitlements: {
+          ...trustedDocument,
+          premium: {...trustedDocument.premium, status: "canceled"},
+        },
+      }),
+      now,
+    }
+  );
+  assert.deepEqual(canceledButEntitled, {
+    tier: "premium",
+    premiumActive: true,
+    trust: "trusted",
+    source: "apple",
+  });
 
-// Client-style flags do not participate in server entitlement resolution.
-const clientFlagIgnored = await resolveAiEntitlement(
-  "uid",
-  {
-    firestore: fakeFirestore({
-      premium: {status: "expired"},
-      isPremium: true,
-      isSubscribed: true,
-    }),
-    now,
-  }
-);
-assert.equal(clientFlagIgnored.tier, "free");
+  const expiredStatus = await resolveAiEntitlement(
+    "uid",
+    {
+      firestore: fakeFirestore({
+        server_entitlements: {
+          ...trustedDocument,
+          premium: {...trustedDocument.premium, status: "expired"},
+        },
+      }),
+      now,
+    }
+  );
+  assert.deepEqual(expiredStatus, {
+    tier: "free",
+    premiumActive: false,
+    trust: "trusted",
+    source: "apple",
+  });
 
-console.log("aiEntitlementService tests passed");
+  const expiredTimestamp = await resolveAiEntitlement(
+    "uid",
+    {
+      firestore: fakeFirestore({
+        server_entitlements: {
+          ...trustedDocument,
+          premium: {...trustedDocument.premium, expiresAt: past},
+        },
+      }),
+      now,
+    }
+  );
+  assert.equal(expiredTimestamp.premiumActive, false);
+  assert.equal(expiredTimestamp.trust, "trusted");
+
+  const invalidSource = await resolveAiEntitlement(
+    "uid",
+    {
+      firestore: fakeFirestore({
+        server_entitlements: {
+          ...trustedDocument,
+          premium: {...trustedDocument.premium, source: "client"},
+        },
+      }),
+      now,
+    }
+  );
+  assert.deepEqual(invalidSource, {
+    tier: "free",
+    premiumActive: false,
+    trust: "none",
+    source: "none",
+  });
+
+  const missingVerifiedAt = await resolveAiEntitlement(
+    "uid",
+    {
+      firestore: fakeFirestore({
+        server_entitlements: {
+          ...trustedDocument,
+          premium: {...trustedDocument.premium, verifiedAt: null},
+        },
+      }),
+      now,
+    }
+  );
+  assert.equal(missingVerifiedAt.premiumActive, false);
+  assert.equal(missingVerifiedAt.trust, "none");
+
+  const noExpiry = await resolveAiEntitlement(
+    "uid",
+    {
+      firestore: fakeFirestore({
+        server_entitlements: {
+          ...trustedDocument,
+          premium: {...trustedDocument.premium, expiresAt: null},
+        },
+      }),
+      now,
+    }
+  );
+  assert.deepEqual(noExpiry, {
+    tier: "free",
+    premiumActive: false,
+    trust: "trusted",
+    source: "apple",
+  });
+
+  const pending = await resolveAiEntitlement(
+    "uid",
+    {
+      firestore: fakeFirestore({
+        server_entitlements: {
+          ...trustedDocument,
+          premium: {...trustedDocument.premium, status: "pending"},
+        },
+      }),
+      now,
+    }
+  );
+  assert.deepEqual(pending, {
+    tier: "free",
+    premiumActive: false,
+    trust: "none",
+    source: "none",
+  });
+
+  console.log("aiEntitlementService tests passed");
 })().catch((error: unknown) => {
   console.error(error);
   process.exitCode = 1;

--- a/functions/src/ai/aiEntitlementService.ts
+++ b/functions/src/ai/aiEntitlementService.ts
@@ -1,16 +1,18 @@
 import * as admin from "firebase-admin";
 
 import {AiEntitlementTier} from "./aiAccessConfig";
+import {
+  readTrustedEntitlement,
+  TrustedEntitlementSource,
+} from "../entitlements/trustedEntitlementService";
 
-export type AiEntitlementSource =
-  | "user_points.premium"
-  | "user_points.premiumExpiry"
-  | "missing_user_points"
-  | "invalid_user_points";
+export type AiEntitlementSource = TrustedEntitlementSource | "none";
+export type AiEntitlementTrust = "trusted" | "none";
 
 export interface AiEntitlement {
   tier: AiEntitlementTier;
   premiumActive: boolean;
+  trust: AiEntitlementTrust;
   source: AiEntitlementSource;
 }
 
@@ -19,79 +21,61 @@ export interface ResolveAiEntitlementOptions {
   now?: Date;
 }
 
-function toDate(value: unknown): Date | null {
-  if (value instanceof Date) return value;
-  if (typeof value === "number" || typeof value === "string") {
-    const date = new Date(value);
-    return Number.isNaN(date.getTime()) ? null : date;
-  }
-  if (typeof value === "object" && value !== null &&
-      "toDate" in value && typeof value.toDate === "function") {
-    const date = value.toDate();
-    return date instanceof Date && !Number.isNaN(date.getTime()) ? date : null;
-  }
-  return null;
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
 function premiumResult(
   active: boolean,
+  trust: AiEntitlementTrust,
   source: AiEntitlementSource
 ): AiEntitlement {
   return {
     tier: active ? "premium" : "free",
     premiumActive: active,
+    trust,
     source,
   };
 }
 
+function noEntitlement(): AiEntitlement {
+  return premiumResult(false, "none", "none");
+}
+
 /**
- * Resolve AI entitlement from the server-side user_points document only.
- * Client payload flags such as premium/isPremium/isSubscribed are never read.
+ * Resolve AI entitlement from the server-owned server_entitlements document.
  *
- * The active/expired semantics intentionally match AdRemoveProvider: a
- * canceled entitlement remains active until its expiry timestamp, while an
- * active/grace/pending status without an expiry is treated as active.
+ * user_points.premium, premiumExpiry, and client request flags are deliberately
+ * outside this resolver's trust boundary. A valid trusted document still needs
+ * a future expiry for premium access; malformed or pending documents fail safe.
  */
 export async function resolveAiEntitlement(
   uid: string,
   options: ResolveAiEntitlementOptions = {}
 ): Promise<AiEntitlement> {
-  const firestore = options.firestore ?? admin.firestore();
-  const now = options.now ?? new Date();
-  const snapshot = await firestore.collection("user_points").doc(uid).get();
+  try {
+    const trusted = await readTrustedEntitlement(uid, {
+      firestore: options.firestore,
+    });
 
-  if (!snapshot.exists) {
-    return premiumResult(false, "missing_user_points");
+    if (!trusted) return noEntitlement();
+
+    const premium = trusted.premium;
+    const now = options.now ?? new Date();
+
+    if (premium.status === "expired" || premium.expiresAt === null ||
+        now >= premium.expiresAt) {
+      return premiumResult(false, "trusted", premium.source);
+    }
+
+    // Canceled subscriptions remain entitled through their verified expiry.
+    const active = premium.status === "active" ||
+      premium.status === "grace" ||
+      premium.status === "canceled";
+
+    return premiumResult(
+      active,
+      "trusted",
+      premium.source
+    );
+  } catch (_error: unknown) {
+    // A failed trusted read must never turn into premium access.
+    return noEntitlement();
   }
-
-  const data = snapshot.data();
-  if (!isRecord(data)) {
-    return premiumResult(false, "invalid_user_points");
-  }
-
-  const premium = data.premium;
-  if (isRecord(premium)) {
-    const status = typeof premium.status === "string" ?
-      premium.status.toLowerCase() :
-      "expired";
-    const expiresAt = toDate(premium.expiresAt);
-    const entitlementValid = expiresAt !== null && now < expiresAt;
-    const statusActive = status === "active" ||
-      status === "grace" ||
-      status === "pending";
-
-    // A future expiry preserves access even when the subscription is canceled.
-    const active = expiresAt !== null ? entitlementValid : statusActive;
-    return premiumResult(active, "user_points.premium");
-  }
-
-  const legacyExpiry = toDate(data.premiumExpiry);
-  return premiumResult(
-    legacyExpiry !== null && now < legacyExpiry,
-    legacyExpiry === null ? "invalid_user_points" : "user_points.premiumExpiry"
-  );
 }

--- a/functions/src/entitlements/trustedEntitlementService.test.ts
+++ b/functions/src/entitlements/trustedEntitlementService.test.ts
@@ -1,0 +1,180 @@
+import assert from "node:assert/strict";
+import * as admin from "firebase-admin";
+
+import {
+  TRUSTED_ENTITLEMENTS_COLLECTION,
+  readTrustedEntitlement,
+  writeTrustedEntitlement,
+} from "../entitlements/trustedEntitlementService";
+
+type DocumentData = Record<string, unknown> | undefined;
+
+function fakeFirestore(
+  data: DocumentData,
+  onSet?: (value: Record<string, unknown>) => void,
+  collectionNames: string[] = []
+): admin.firestore.Firestore {
+  return {
+    collection: (name: string) => {
+      collectionNames.push(name);
+      return {
+        doc: () => ({
+          get: async () => ({
+            exists: data !== undefined,
+            data: () => data,
+          }),
+          set: async (value: Record<string, unknown>) => {
+            onSet?.(value);
+          },
+        }),
+      };
+    },
+  } as unknown as admin.firestore.Firestore;
+}
+
+void (async () => {
+  const now = new Date("2026-08-29T00:00:00.000Z");
+  const future = admin.firestore.Timestamp.fromDate(
+    new Date("2026-08-30T00:00:00.000Z")
+  );
+  const verifiedAt = admin.firestore.Timestamp.fromDate(now);
+
+  const validDocument = {
+    premium: {
+      status: "active",
+      expiresAt: future,
+      verifiedAt,
+      source: "apple",
+      productId: "premium.monthly",
+    },
+    updatedAt: verifiedAt,
+  };
+
+  const missing = await readTrustedEntitlement(
+    "uid",
+    {firestore: fakeFirestore(undefined)}
+  );
+  assert.equal(missing, null);
+
+  const valid = await readTrustedEntitlement(
+    "uid",
+    {firestore: fakeFirestore(validDocument)}
+  );
+  assert.equal(valid?.premium.source, "apple");
+
+  const missingProductId = await readTrustedEntitlement(
+    "uid",
+    {
+      firestore: fakeFirestore({
+        ...validDocument,
+        premium: {...validDocument.premium, productId: undefined},
+      }),
+    }
+  );
+  assert.equal(missingProductId, null);
+
+  const missingVerifiedAt = await readTrustedEntitlement(
+    "uid",
+    {
+      firestore: fakeFirestore({
+        ...validDocument,
+        premium: {...validDocument.premium, verifiedAt: null},
+      }),
+    }
+  );
+  assert.equal(missingVerifiedAt, null);
+
+  const invalidSource = await readTrustedEntitlement(
+    "uid",
+    {
+      firestore: fakeFirestore({
+        ...validDocument,
+        premium: {...validDocument.premium, source: "client"},
+      }),
+    }
+  );
+  assert.equal(invalidSource, null);
+
+  const pendingStatus = await readTrustedEntitlement(
+    "uid",
+    {
+      firestore: fakeFirestore({
+        ...validDocument,
+        premium: {...validDocument.premium, status: "pending"},
+      }),
+    }
+  );
+  assert.equal(pendingStatus, null);
+
+  const collectionNames: string[] = [];
+  const userPointsOnly = await readTrustedEntitlement(
+    "uid",
+    {
+      firestore: fakeFirestore(
+        undefined,
+        undefined,
+        collectionNames
+      ),
+    }
+  );
+  assert.equal(userPointsOnly, null);
+  assert.deepEqual(collectionNames, [TRUSTED_ENTITLEMENTS_COLLECTION]);
+
+  let written: Record<string, unknown> | undefined;
+  await writeTrustedEntitlement(
+    "uid",
+    {
+      verifiedSource: "google",
+      verifiedStatus: "active",
+      verifiedExpiresAt: future,
+      verifiedProductId: "premium.yearly",
+    },
+    {firestore: fakeFirestore(undefined, (value) => written = value)}
+  );
+  assert.equal(written?.premium &&
+  (written.premium as Record<string, unknown>).source, "google");
+  assert.equal(written?.premium &&
+  (written.premium as Record<string, unknown>).productId, "premium.yearly");
+  assert.ok(written?.premium &&
+  (written.premium as Record<string, unknown>).verifiedAt);
+  assert.ok(written?.updatedAt);
+
+  await assert.rejects(
+    () => writeTrustedEntitlement(
+      "uid",
+      {
+        verifiedSource: "client" as "apple",
+        verifiedExpiresAt: future,
+      }
+    ),
+    /Invalid verified entitlement metadata/
+  );
+
+  await assert.rejects(
+    () => writeTrustedEntitlement(
+      "uid",
+      {
+        verifiedSource: "apple",
+        verifiedExpiresAt: "future" as unknown as Date,
+      }
+    ),
+    /verifiedExpiresAt must be a valid server date/
+  );
+
+  await assert.rejects(
+    () => writeTrustedEntitlement(
+      "uid",
+      {
+        verifiedSource: "apple",
+        verifiedStatus: "pending" as "active",
+        verifiedExpiresAt: future,
+      }
+    ),
+    /Invalid verified entitlement metadata/
+  );
+
+  console.log("trustedEntitlementService tests passed");
+})().catch((error: unknown) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/functions/src/entitlements/trustedEntitlementService.ts
+++ b/functions/src/entitlements/trustedEntitlementService.ts
@@ -1,0 +1,180 @@
+import * as admin from "firebase-admin";
+
+export const TRUSTED_ENTITLEMENTS_COLLECTION = "server_entitlements";
+
+export type TrustedEntitlementSource =
+  | "apple"
+  | "google"
+  | "migration"
+  | "admin";
+
+export type TrustedEntitlementStatus =
+  | "active"
+  | "grace"
+  | "canceled"
+  | "expired";
+
+export interface TrustedPremiumEntitlement {
+  status: TrustedEntitlementStatus;
+  expiresAt: Date | null;
+  verifiedAt: Date;
+  source: TrustedEntitlementSource;
+  productId: string | null;
+}
+
+export interface TrustedEntitlement {
+  premium: TrustedPremiumEntitlement;
+  updatedAt: Date;
+}
+
+/**
+ * This is the narrow input accepted from a future server-side store verifier.
+ * It intentionally has no request payload or arbitrary map escape hatch.
+ */
+export interface VerifiedEntitlementResult {
+  verifiedSource: TrustedEntitlementSource;
+  verifiedStatus?: TrustedEntitlementStatus;
+  verifiedExpiresAt: Date | admin.firestore.Timestamp | null;
+  verifiedProductId?: string | null;
+}
+
+export interface TrustedEntitlementServiceOptions {
+  firestore?: admin.firestore.Firestore;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function toDate(value: unknown): Date | null {
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? null : value;
+  }
+
+  if (typeof value === "object" && value !== null &&
+      "toDate" in value && typeof value.toDate === "function") {
+    const date = value.toDate();
+    return date instanceof Date && !Number.isNaN(date.getTime()) ? date : null;
+  }
+
+  return null;
+}
+
+function isTrustedSource(value: unknown): value is TrustedEntitlementSource {
+  return value === "apple" || value === "google" ||
+    value === "migration" || value === "admin";
+}
+
+function isTrustedStatus(value: unknown): value is TrustedEntitlementStatus {
+  return value === "active" || value === "grace" ||
+    value === "canceled" || value === "expired";
+}
+
+function normalizeUid(uid: string): string {
+  if (typeof uid !== "string" || !uid.trim()) {
+    throw new Error("Trusted entitlement uid is required.");
+  }
+  return uid.trim();
+}
+
+function entitlementRef(
+  firestore: admin.firestore.Firestore,
+  uid: string
+): admin.firestore.DocumentReference {
+  return firestore.collection(TRUSTED_ENTITLEMENTS_COLLECTION).doc(uid);
+}
+
+/**
+ * Read and validate the server-owned entitlement document.
+ * Any missing or malformed trust metadata is treated as no entitlement.
+ */
+export async function readTrustedEntitlement(
+  uid: string,
+  options: TrustedEntitlementServiceOptions = {}
+): Promise<TrustedEntitlement | null> {
+  const firestore = options.firestore ?? admin.firestore();
+  const snapshot = await entitlementRef(firestore, normalizeUid(uid)).get();
+
+  if (!snapshot.exists) return null;
+
+  const data = snapshot.data() ?? {};
+  const premium = isRecord(data?.premium) ? data.premium : null;
+  if (!premium || !isTrustedStatus(premium.status) ||
+      !isTrustedSource(premium.source)) {
+    return null;
+  }
+
+  if (!Object.prototype.hasOwnProperty.call(premium, "productId")) {
+    return null;
+  }
+
+  const verifiedAt = toDate(premium.verifiedAt);
+  const updatedAt = toDate(data?.updatedAt);
+  const expiresAt = premium.expiresAt === null ?
+    null : toDate(premium.expiresAt);
+  const productId = premium.productId === null ?
+    null : premium.productId;
+
+  if (!verifiedAt || !updatedAt ||
+      (premium.expiresAt !== null && !expiresAt) ||
+      (productId !== null && typeof productId !== "string")) {
+    return null;
+  }
+
+  return {
+    premium: {
+      status: premium.status,
+      expiresAt,
+      verifiedAt,
+      source: premium.source,
+      productId,
+    },
+    updatedAt,
+  };
+}
+
+/**
+ * Write a trusted entitlement from a server-side verified result only.
+ * Firestore server timestamps are used for all trust metadata generated here.
+ */
+export async function writeTrustedEntitlement(
+  uid: string,
+  verified: VerifiedEntitlementResult,
+  options: TrustedEntitlementServiceOptions = {}
+): Promise<void> {
+  const normalizedUid = normalizeUid(uid);
+  if (!isRecord(verified)) {
+    throw new Error("Invalid verified entitlement metadata.");
+  }
+  const status = verified.verifiedStatus ?? "active";
+
+  if (!isTrustedSource(verified.verifiedSource) ||
+      !isTrustedStatus(status)) {
+    throw new Error("Invalid verified entitlement metadata.");
+  }
+
+  const expiresAt = verified.verifiedExpiresAt === null ?
+    null : toDate(verified.verifiedExpiresAt);
+  if (verified.verifiedExpiresAt !== null && !expiresAt) {
+    throw new Error("verifiedExpiresAt must be a valid server date.");
+  }
+
+  const productId = verified.verifiedProductId ?? null;
+  if (productId !== null && typeof productId !== "string") {
+    throw new Error("verifiedProductId must be a string or null.");
+  }
+
+  const firestore = options.firestore ?? admin.firestore();
+  const timestamp = admin.firestore.FieldValue.serverTimestamp();
+  await entitlementRef(firestore, normalizedUid).set({
+    premium: {
+      status,
+      expiresAt: expiresAt === null ? null :
+        admin.firestore.Timestamp.fromDate(expiresAt),
+      verifiedAt: timestamp,
+      source: verified.verifiedSource,
+      productId,
+    },
+    updatedAt: timestamp,
+  });
+}


### PR DESCRIPTION
## Summary

- separates client premium UX state from trusted server entitlement
- AI quota eligibility reads only server_entitlements
- rejects client user_points premium, pending, malformed, and unverified entitlement data
- adds a server-side trusted entitlement reader/writer abstraction
- logs entitlement trust, tier, and source without sensitive purchase data
- keeps quota enforcement OFF
- keeps App Check hard enforcement OFF
- does not implement fake Apple or Google store verification
- preserves Vision behavior and purchase UI behavior
- no production deployment

## Validation

- flutter analyze
- flutter test
- npm run build
- npm run lint
- npm run test:entitlement
- npm run test:ai-access
- npm run test:vision-request
- git diff --check

## Follow-up

The repository does not contain firestore.rules, so production Firestore rules must explicitly deny client writes to server_entitlements before deployment.